### PR TITLE
Fixes retrieving the swift mail transport from the app container in Laravel 7

### DIFF
--- a/src/WithMailInterceptor.php
+++ b/src/WithMailInterceptor.php
@@ -43,6 +43,11 @@ trait WithMailInterceptor
      */
     public function interceptedMail(): Collection
     {
-        return app('swift.transport')->driver()->messages();
+        $swiftTransport = (version_compare(app()->version(), '7.0.0', '<'))
+            ? app('swift.transport')
+            : (app('mailer')->getSwiftMailer())->getTransport();
+
+        return $swiftTransport->driver()->messages();
     }
+
 }

--- a/src/WithMailInterceptor.php
+++ b/src/WithMailInterceptor.php
@@ -49,5 +49,4 @@ trait WithMailInterceptor
 
         return $swiftTransport->driver()->messages();
     }
-
 }


### PR DESCRIPTION
Laravel 7 removes the swift.transport binding from the app container. [Upgrade guide](https://laravel.com/docs/7.x/upgrade):

> Laravel 7.x doesn't provide swift.mailer and swift.transport container bindings. You may now access these objects through the mailer binding:

```
$swiftMailer = app('mailer')->getSwiftMailer();
$swiftTransport = $swiftMailer->getTransport();
```