### PR TITLE
fixes TransportManager changes in Laravel 7

### DIFF
--- a/src/WithMailInterceptor.php
+++ b/src/WithMailInterceptor.php
@@ -44,9 +44,9 @@ trait WithMailInterceptor
     public function interceptedMail(): Collection
     {
         $swiftTransport = (version_compare(app()->version(), '7.0.0', '<'))
-            ? app('swift.transport')
+            ? app('swift.transport')->driver()
             : (app('mailer')->getSwiftMailer())->getTransport();
 
-        return $swiftTransport->driver()->messages();
+        return $swiftTransport->messages();
     }
 }


### PR DESCRIPTION
Prior to Laravel 7, `app('swift.transport')` actually returns a `TransportManager` object, (calling `->driver()` on that gives you the `ArrayTransport` that matches the new retrieval through `app('mailer')->...`)