### PR TITLE
Laravel 9 updates and many new assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,42 +2,6 @@ on: push
 name: CI
 
 jobs:
-  phpunit-php73:
-    name: PHP 7.3
-    runs-on: ubuntu-latest
-    container:
-      image: kirschbaumdevelopment/laravel-test-runner:7.3
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-
-    - name: Install composer dependencies
-      run: |
-        composer install --prefer-dist --no-interaction --no-scripts
-
-    - name: Run Testsuite
-      run: vendor/bin/phpunit tests/
-
-  phpunit-php74:
-    name: PHP 7.4
-    runs-on: ubuntu-latest
-    container:
-      image: kirschbaumdevelopment/laravel-test-runner:7.4
-
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-
-      - name: Install composer dependencies
-        run: |
-          composer install --prefer-dist --no-interaction --no-scripts
-
-      - name: Run Testsuite
-        run: vendor/bin/phpunit tests/
-
   phpunit-php80:
     name: PHP 8.0
     runs-on: ubuntu-latest
@@ -55,3 +19,21 @@ jobs:
 
       - name: Run Testsuite
         run: vendor/bin/phpunit tests/
+
+  phpunit-php81:
+      name: PHP 8.1
+      runs-on: ubuntu-latest
+      container:
+          image: kirschbaumdevelopment/laravel-test-runner:8.1
+
+      steps:
+          - uses: actions/checkout@v1
+            with:
+                fetch-depth: 1
+
+          - name: Install composer dependencies
+            run: |
+                composer install --prefer-dist --no-interaction --no-scripts
+
+          - name: Run Testsuite
+            run: vendor/bin/phpunit tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to `mail-intercept` will be documented in this file
 
+## 0.3.0 - 2022-03-08
+
+- Upgraded for Laravel 9
+- New fluent syntax for making assertions directly on each message.
+- Added new assertions methods:
+  - `assertMailHasPlainContent`
+  - `assertMailDoesNotHavePlainContent`
+  - `assertMailHasHtmlContent`
+  - `assertMailDoesNotHaveHtmlContent`
+  - `assertMailIsAlternative`
+  - `assertMailIsNotAlternative`
+  - `assertMailIsMixed`
+  - `assertMailIsNotMixed`
+  - `assertMailPriority`
+  - `assertMailNotPriority`
+  - `assertMailPriorityIsHighest`
+  - `assertMailPriorityNotHighest`
+  - `assertMailPriorityIsHigh`
+  - `assertMailPriorityNotHigh`
+  - `assertMailPriorityIsNormal`
+  - `assertMailPriorityNotNormal`
+  - `assertMailPriorityIsLow`
+  - `assertMailPriorityNotLow`
+  - `assertMailPriorityIsLowest`
+  - `assertMailPriorityNotLowest`
+  - `assertMailReturnPath`
+  - `assertMailNotReturnPath`
+
 ## 0.2.2 - 2020-03-11
 
 - Added coverage for string assertion deprecations if using PHPUnit < 8.0

--- a/README.md
+++ b/README.md
@@ -54,12 +54,26 @@ class MailTest extends TestCase
 
         $interceptedMail = $this->interceptedMail()->first();
 
-        $this->assertMailSentTo($email, $interceptedMail);
+        $interceptedMail->assertSentTo($email);
     }
 }
 ```
 
 That's it! Pretty simple, right?!
+
+There are two ways of accessing the assertions. First is the fluent syntax directly on each intercepted email.
+
+```php
+$interceptedMail->assertSentTo($email);
+```
+
+The other way (the older way) is to use the assertions methods made available from the `WithMailInterceptor` trait. Using these methods are fine, but aren't as clean to write.
+
+```php
+$this->assertMailSentTo($email, $interceptedEmail);
+```
+
+Both of these assertions do the exact same thing, the fluent one is just much cleaner. See all the available assertion methods below!
 
 ### Testing API
 
@@ -74,6 +88,68 @@ $this->interceptedMail()
 ```
 
 This should be called after `Mail` has been sent, but before your assertions, otherwise you won't have any emails to work with. It returns a `Collection` of emails so you are free to use any of the methods available to a collection.
+
+#### Fluent Assertion Methods
+
+| Assertions                                             | Parameters              |
+|:-------------------------------------------------------|:------------------------|
+| `$intercepted->assertSentTo($to);`                     | `$to` array, string     |
+| `$intercepted->assertNotSentTo($to);`                  | `$to` array, string     |
+| `$intercepted->assertSentFrom($from);`                 | `$from` array, string   |
+| `$intercepted->assertNotSentFrom($from);`              | `$from` array, string   |
+| `$intercepted->assertSubject($subject);`               | `$subject` string       |
+| `$intercepted->assertNotSubject($subject);`            | `$subject` string       |
+| `$intercepted->assertBodyContainsString($content);`    | `$content` string       |
+| `$intercepted->assertBodyNotContainsString($content);` | `$content` string       |
+| `$intercepted->assertRepliesTo($reply);`               | `$reply` array, string  |
+| `$intercepted->assertNotRepliesTo($reply);`            | `$reply` array, string  |
+| `$intercepted->assertCc($cc);`                         | `$cc` array, string     |
+| `$intercepted->assertNotCc($cc);`                      | `$cc` array, string     |
+| `$intercepted->assertBcc($cc);`                        | `$bcc` array, string    |
+| `$intercepted->assertNotBcc($cc);`                     | `$bcc` array, string    |
+| `$intercepted->assertSender($sender);`                 | `$sender` array, string |
+| `$intercepted->assertNotSender($sender);`              | `$sender` array, string |
+| `$intercepted->assertReturnPath($returnPath);`         | `$returnPath` string    |
+| `$intercepted->assertNotReturnPath($returnPath);`      | `$returnPath` string    |
+
+| Content Type Assertions                          | 
+|:-------------------------------------------------|
+| `$intercepted->assertIsPlain();`                 |
+| `$intercepted->assertIsNotPlain();`              |
+| `$intercepted->assertHasPlainContent();`         |
+| `$intercepted->assertDoesNotHavePlainContent();` |
+| `$intercepted->assertIsHtml();`                  |
+| `$intercepted->assertIsNotHtml();`               |
+| `$intercepted->assertHasHtmlContent();`          |
+| `$intercepted->assertDoesNotHaveHtmlContent();`  |
+| `$intercepted->assertIsAlternative();`           |
+| `$intercepted->assertIsNotAlternative();`        |
+| `$intercepted->assertIsMixed();`                 |
+| `$intercepted->assertIsNotMixed();`              |
+
+| Header Assertions                                   | Parameters                           |
+|:----------------------------------------------------|:-------------------------------------|
+| `$intercepted->assertHasHeader($header);`           | `$header` string                     |
+| `$intercepted->assertMissingHeader($header);`       | `$header` string                     |
+| `$intercepted->assertHeaderIs($header, $value);`    | `$header` string<br/>`$value` string |
+| `$intercepted->assertHeaderIsNot($header, $value);` | `$header` string<br/>`$value` string |
+
+| Priority Assertions                           | Parameters      |
+|:----------------------------------------------|:----------------|
+| `$intercepted->assertPriority($priority);`    | `$priority` int |
+| `$intercepted->assertNotPriority($priority);` | `$priority` int |
+| `$intercepted->assertPriorityIsHighest();`    |                 |
+| `$intercepted->assertPriorityNotHighest();`   |                 |
+| `$intercepted->assertPriorityIsHigh();`       |                 |
+| `$intercepted->assertPriorityNotHigh();`      |                 |
+| `$intercepted->assertPriorityIsNormal();`     |                 |
+| `$intercepted->assertPriorityNotNormal();`    |                 |
+| `$intercepted->assertPriorityIsLow();`        |                 |
+| `$intercepted->assertPriorityNotLow();`       |                 |
+| `$intercepted->assertPriorityIsLowest();`     |                 |
+| `$intercepted->assertPriorityIsLowest();`     |                 |
+
+#### Assertion Methods
 
 | Assertions                                                 | Parameters                                |
 |:-----------------------------------------------------------|:------------------------------------------|
@@ -139,7 +215,7 @@ If you are injecting your own headers or need access to other headers in the ema
 
 ### Other assertions
 
-Since `$this->interceptedMail()` returns a collection of `Symfony\Component\Mime\Email` objects, you are free to dissect and look into those objects using any methods available to Symfony's Email API. Head over to the [Symfony Email Docs](https://symfony.com/doc/current/mailer.html) for more detailed info.
+Since `$this->interceptedMail()` returns a collection of `AssertableMessage` objects. You are free to dissect and look into those objects using any methods available to Symfony's Email API. Head over to the [Symfony Email Docs](https://symfony.com/doc/current/mailer.html) for more detailed info.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Mail isn't faked here. You get to inspect the actual mail ensuring you are sendi
 
 ## Requirements
 
-This testing package requires Laravel 5.5 or higher.
+| Laravel Version  | Mail Intercept Version  |
+|:-----------------|:------------------------|
+| 9.x              | 0.3.x                   |
+| 8.x and lower    | 0.2.x                   |
+
+Please note: If you are using `v0.2.x`, please refer to that version's [documentation](https://github.com/kirschbaum-development/mail-intercept/tree/v0.2.x).
 
 ## Installation
 
@@ -36,8 +41,8 @@ use KirschbaumDevelopment\MailIntercept\WithMailInterceptor;
 
 class MailTest extends TestCase
 {
-    use WithFaker,
-        WithMailInterceptor;
+    use WithFaker;
+    use WithMailInterceptor;
 
     public function testMail()
     {
@@ -70,35 +75,63 @@ $this->interceptedMail()
 
 This should be called after `Mail` has been sent, but before your assertions, otherwise you won't have any emails to work with. It returns a `Collection` of emails so you are free to use any of the methods available to a collection.
 
-| Assertions                                                 | Parameters                                        |
-|:---------------------------------------------------------- |:--------------------------------------------------|
-| `$this->assertMailSentTo($to, $mail);`                     | `$to` string, array<br/>`$mail` Swift_Message     |
-| `$this->assertMailNotSentTo($to, $mail);`                  | `$to` string, array<br/>`$mail` Swift_Message     |
-| `$this->assertMailSentFrom($from, $mail);`                 | `$from` string, array<br/>`$mail` Swift_Message   |
-| `$this->assertMailNotSentFrom($from, $mail);`              | `$from` string, array<br/>`$mail` Swift_Message   |
-| `$this->assertMailSubject($subject, $mail);`               | `$subject` string<br/>`$mail` Swift_Message       |
-| `$this->assertMailNotSubject($subject, $mail);`            | `$subject` string<br/>`$mail` Swift_Message       |
-| `$this->assertMailBodyContainsString($content, $mail);`    | `$content` string<br/>`$mail` Swift_Message       |
-| `$this->assertMailBodyNotContainsString($content, $mail);` | `$content` string<br/>`$mail` Swift_Message       |
-| `$this->assertMailRepliesTo($reply, $mail);`               | `$reply` string, array<br/>`$mail` Swift_Message  |
-| `$this->assertMailNotRepliesTo($reply, $mail);`            | `$reply` string, array<br/>`$mail` Swift_Message  |
-| `$this->assertMailCc($cc, $mail);`                         | `$cc` string, array<br/>`$mail` Swift_Message     |
-| `$this->assertMailNotCc($cc, $mail);`                      | `$cc` string, array<br/>`$mail` Swift_Message     |
-| `$this->assertMailBcc($cc, $mail);`                        | `$bcc` string, array<br/>`$mail` Swift_Message    |
-| `$this->assertMailNotBcc($cc, $mail);`                     | `$bcc` string, array<br/>`$mail` Swift_Message    |
-| `$this->assertMailSender($sender, $mail);`                 | `$sender` string, array<br/>`$mail` Swift_Message |
-| `$this->assertMailNotSender($sender, $mail);`              | `$sender` string, array<br/>`$mail` Swift_Message |
-| `$this->assertMailIsPlain($mail);`                         | `$mail` Swift_Message                             |
-| `$this->assertMailIsNotPlain($mail);`                      | `$mail` Swift_Message                             |
-| `$this->assertMailIsHtml($mail);`                          | `$mail` Swift_Message                             |
-| `$this->assertMailIsNotHtml($mail);`                       | `$mail` Swift_Message                             |
+| Assertions                                                 | Parameters                                |
+|:-----------------------------------------------------------|:------------------------------------------|
+| `$this->assertMailSentTo($to, $mail);`                     | `$to` array, string<br/>`$mail` Email     |
+| `$this->assertMailNotSentTo($to, $mail);`                  | `$to` array, string<br/>`$mail` Email     |
+| `$this->assertMailSentFrom($from, $mail);`                 | `$from` array, string<br/>`$mail` Email   |
+| `$this->assertMailNotSentFrom($from, $mail);`              | `$from` array, string<br/>`$mail` Email   |
+| `$this->assertMailSubject($subject, $mail);`               | `$subject` string<br/>`$mail` Email       |
+| `$this->assertMailNotSubject($subject, $mail);`            | `$subject` string<br/>`$mail` Email       |
+| `$this->assertMailBodyContainsString($content, $mail);`    | `$content` string<br/>`$mail` Email       |
+| `$this->assertMailBodyNotContainsString($content, $mail);` | `$content` string<br/>`$mail` Email       |
+| `$this->assertMailRepliesTo($reply, $mail);`               | `$reply` array, string<br/>`$mail` Email  |
+| `$this->assertMailNotRepliesTo($reply, $mail);`            | `$reply` array, string<br/>`$mail` Email  |
+| `$this->assertMailCc($cc, $mail);`                         | `$cc` array, string<br/>`$mail` Email     |
+| `$this->assertMailNotCc($cc, $mail);`                      | `$cc` array, string<br/>`$mail` Email     |
+| `$this->assertMailBcc($cc, $mail);`                        | `$bcc` array, string<br/>`$mail` Email    |
+| `$this->assertMailNotBcc($cc, $mail);`                     | `$bcc` array, string<br/>`$mail` Email    |
+| `$this->assertMailSender($sender, $mail);`                 | `$sender` array, string<br/>`$mail` Email |
+| `$this->assertMailNotSender($sender, $mail);`              | `$sender` array, string<br/>`$mail` Email |
+| `$this->assertMailReturnPath($returnPath, $mail);`         | `$returnPath` string<br/>`$mail` Email    |
+| `$this->assertMailNotReturnPath($returnPath, $mail);`      | `$returnPath` string<br/>`$mail` Email    |
 
-| Header Assertions                                       | Parameters                                                     |
-|:------------------------------------------------------- |:---------------------------------------------------------------|
-| `$this->assertMailHasHeader($header, $mail);`           | `$header` string<br/>`$mail` Swift_Message                     |
-| `$this->assertMailMissingHeader($header, $mail);`       | `$header` string<br/>`$mail` Swift_Message                     |
-| `$this->assertMailHeaderIs($header, $value, $mail);`    | `$header` string<br/>`$value` string<br/>`$mail` Swift_Message |
-| `$this->assertMailHeaderIsNot($header, $value, $mail);` | `$header` string<br/>`$value` string<br/>`$mail` Swift_Message |
+| Content Type Assertions                            | Parameters    |
+|:---------------------------------------------------|:--------------|
+| `$this->assertMailIsPlain($mail);`                 | `$mail` Email |
+| `$this->assertMailIsNotPlain($mail);`              | `$mail` Email |
+| `$this->assertMailHasPlainContent($mail);`         | `$mail` Email |
+| `$this->assertMailDoesNotHavePlainContent($mail);` | `$mail` Email |
+| `$this->assertMailIsHtml($mail);`                  | `$mail` Email |
+| `$this->assertMailIsNotHtml($mail);`               | `$mail` Email |
+| `$this->assertMailHasHtmlContent($mail);`          | `$mail` Email |
+| `$this->assertMailDoesNotHaveHtmlContent($mail);`  | `$mail` Email |
+| `$this->assertMailIsAlternative($mail);`           | `$mail` Email |
+| `$this->assertMailIsNotAlternative($mail);`        | `$mail` Email |
+| `$this->assertMailIsMixed($mail);`                 | `$mail` Email |
+| `$this->assertMailIsNotMixed($mail);`              | `$mail` Email |
+
+| Header Assertions                                       | Parameters                                             |
+|:--------------------------------------------------------|:-------------------------------------------------------|
+| `$this->assertMailHasHeader($header, $mail);`           | `$header` string<br/>`$mail` Email                     |
+| `$this->assertMailMissingHeader($header, $mail);`       | `$header` string<br/>`$mail` Email                     |
+| `$this->assertMailHeaderIs($header, $value, $mail);`    | `$header` string<br/>`$value` string<br/>`$mail` Email |
+| `$this->assertMailHeaderIsNot($header, $value, $mail);` | `$header` string<br/>`$value` string<br/>`$mail` Email |
+
+| Priority Assertions                               | Parameters                        |
+|:--------------------------------------------------|:----------------------------------|
+| `$this->assertMailPriority($priority, $mail);`    | `$priority` int<br/>`$mail` Email |
+| `$this->assertMailNotPriority($priority, $mail);` | `$priority` int<br/>`$mail` Email |
+| `$this->assertMailPriorityIsHighest($mail);`      | `$mail` Email                     |
+| `$this->assertMailPriorityNotHighest($mail);`     | `$mail` Email                     |
+| `$this->assertMailPriorityIsHigh($mail);`         | `$mail` Email                     |
+| `$this->assertMailPriorityNotHigh($mail);`        | `$mail` Email                     |
+| `$this->assertMailPriorityIsNormal($mail);`       | `$mail` Email                     |
+| `$this->assertMailPriorityNotNormal($mail);`      | `$mail` Email                     |
+| `$this->assertMailPriorityIsLow($mail);`          | `$mail` Email                     |
+| `$this->assertMailPriorityNotLow($mail);`         | `$mail` Email                     |
+| `$this->assertMailPriorityIsLowest($mail);`       | `$mail` Email                     |
+| `$this->assertMailPriorityIsLowest($mail);`       | `$mail` Email                     |
 
 You should use each item of the `interceptedMail()` collection as the mail object for all assertions.
 
@@ -106,7 +139,7 @@ If you are injecting your own headers or need access to other headers in the ema
 
 ### Other assertions
 
-Since `$this->interceptedMail()` returns a collection of `Swift_Message` objects, you are free to dissect and look into those objects using any methods available to Swift's Message API. Head over to the [Swift Mail Docs](https://swiftmailer.symfony.com/docs/introduction.html) for more detailed info.
+Since `$this->interceptedMail()` returns a collection of `Symfony\Component\Mime\Email` objects, you are free to dissect and look into those objects using any methods available to Symfony's Email API. Head over to the [Symfony Email Docs](https://symfony.com/doc/current/mailer.html) for more detailed info.
 
 ## Changelog
 
@@ -123,6 +156,7 @@ If you discover any security related issues, please email brandon@kirschbaumdeve
 ## Credits
 
 - [Brandon Ferens](https://github.com/brandonferens)
+- [Michael Fox](https://github.com/michaelfox)
 
 ## Sponsorship
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A test package for intercepting email sent from Laravel",
     "keywords": [
         "laravel",
-        "swift mailer",
+        "symfony mailer",
         "test",
         "email"
     ],
@@ -18,14 +18,13 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "laravel/framework": "^9.2"
+        "illuminate/mail": "^9.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.2",
-        "orchestra/testbench": ">=3.5",
-        "phpunit/phpunit": ">=6.0",
-        "spatie/ray": "^1.34",
-        "swiftmailer/swiftmailer": "^6.0"
+        "friendsofphp/php-cs-fixer": "^3.7",
+        "orchestra/testbench": "^7.1",
+        "phpunit/phpunit": "^9.5.10",
+        "spatie/ray": "^1.34"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "laravel/framework": ">=5.5"
+        "php": "^8.0.2",
+        "laravel/framework": "^9.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
         "orchestra/testbench": ">=3.5",
         "phpunit/phpunit": ">=6.0",
+        "spatie/ray": "^1.34",
         "swiftmailer/swiftmailer": "^6.0"
     },
     "autoload": {

--- a/src/AssertableMessage.php
+++ b/src/AssertableMessage.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace KirschbaumDevelopment\MailIntercept;
+
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Mime\Email;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * @method assertBcc(array|string $expected)
+ * @method assertNotBcc(array|string $expected)
+ * @method assertCc(array|string $expected)
+ * @method assertNotCc(array|string $expected)
+ * @method assertBodyContainsString(string $needle)
+ * @method assertBodyNotContainsString(string $needle)
+ * @method assertIsPlain
+ * @method assertIsNotPlain
+ * @method assertHasPlainContent
+ * @method assertDoesNotHavePlainContent
+ * @method assertIsHtml
+ * @method assertIsNotHtml
+ * @method assertHasHtmlContent
+ * @method assertDoesNotHaveHtmlContent
+ * @method assertIsAlternative
+ * @method assertIsNotAlternative
+ * @method assertIsMixed
+ * @method assertIsNotMixed
+ * @method assertSentFrom(array|string $expected)
+ * @method assertNotSentFrom(array|string $expected)
+ * @method assertPriority(int $priority)
+ * @method assertNotPriority(int $priority)
+ * @method assertPriorityIsHighest
+ * @method assertPriorityNotHighest
+ * @method assertPriorityIsHigh
+ * @method assertPriorityNotHigh
+ * @method assertPriorityIsNormal
+ * @method assertPriorityNotNormal
+ * @method assertPriorityIsLow
+ * @method assertPriorityNotLow
+ * @method assertPriorityIsLowest
+ * @method assertPriorityNotLowest
+ * @method assertRepliesTo(array|string $expected)
+ * @method assertNotRepliesTo(array|string $expected)
+ * @method assertReturnPath(array|string $expected)
+ * @method assertNotReturnPath(array|string $expected)
+ * @method assertSender(array|string $expected)
+ * @method assertNotSender(array|string $expected)
+ * @method assertSubject(array|string $expected)
+ * @method assertNotSubject(array|string $expected)
+ * @method assertSentTo(array|string $expected)
+ * @method assertNotSentTo(array|string $expected)
+ * @method assertHasHeader(string $expected)
+ * @method assertMissingHeader(string $expected)
+ * @method assertHeaderIs(string $expected, string $expectedValue)
+ * @method assertHeaderIsNot(string $expected, string $expectedValue)
+ */
+class AssertableMessage extends Assert
+{
+    use ForwardsCalls;
+    use WithMailInterceptor;
+
+    /**
+     * The Symfony SentMessage instance.
+     *
+     * @var Email
+     */
+    protected Email $email;
+
+    /**
+     * Create a new SentMessage instance.
+     *
+     * @param Email $email
+     */
+    public function __construct(Email $email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * Dynamically pass missing methods to the Symfony instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     *
+     * @return mixed
+     */
+    public function __call(string $method, array $parameters)
+    {
+        if (Str::startsWith($method, 'assert')) {
+            $assertion = 'assertMail' . Str::after($method, 'assert');
+            $parameters[] = $this->email;
+
+            return $this->$assertion(...$parameters);
+        }
+
+        return $this->forwardCallTo($this->email, $method, $parameters);
+    }
+}

--- a/src/Assertions/BccAssertions.php
+++ b/src/Assertions/BccAssertions.php
@@ -2,25 +2,26 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
 use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait BccAssertions
 {
     /**
      * Assert mail was BCC'd to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailBcc($expected, Swift_Message $mail)
+    public function assertMailBcc(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getBcc', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertContains(
                 $address,
-                array_keys($mail->getBcc()),
+                $actualAddresses,
                 "Mail was not BCC'd to the expected address [{$address}]."
             );
         }
@@ -29,17 +30,18 @@ trait BccAssertions
     /**
      * Assert mail was not BCC'd to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailNotBcc($expected, Swift_Message $mail)
+    public function assertMailNotBcc(array|string $expected, Email $mail)
     {
         $addresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getBcc', $mail);
 
         foreach ($addresses as $address) {
             $this->assertNotContains(
                 $address,
-                array_keys($mail->getBcc()),
+                $actualAddresses,
                 "Mail was BCC'd to the expected address [{$address}]."
             );
         }

--- a/src/Assertions/CcAssertions.php
+++ b/src/Assertions/CcAssertions.php
@@ -2,25 +2,26 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
 use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait CcAssertions
 {
     /**
      * Assert mail was CC'd to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailCc($expected, Swift_Message $mail)
+    public function assertMailCc(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getCc', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertContains(
                 $address,
-                array_keys($mail->getCc()),
+                $actualAddresses,
                 "Mail was not CC'd to the expected address [{$address}]."
             );
         }
@@ -29,17 +30,18 @@ trait CcAssertions
     /**
      * Assert mail was not CC'd to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailNotCc($expected, Swift_Message $mail)
+    public function assertMailNotCc(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getCc', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertNotContains(
                 $address,
-                array_keys($mail->getCc()),
+                $actualAddresses,
                 "Mail was CC'd to the expected address [{$address}]."
             );
         }

--- a/src/Assertions/ContentAssertions.php
+++ b/src/Assertions/ContentAssertions.php
@@ -2,7 +2,7 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
+use Symfony\Component\Mime\Email;
 
 trait ContentAssertions
 {
@@ -10,9 +10,9 @@ trait ContentAssertions
      * Assert mail body contains string.
      *
      * @param string $needle
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailBodyContainsString(string $needle, Swift_Message $mail)
+    public function assertMailBodyContainsString(string $needle, Email $mail)
     {
         $method = method_exists($this, 'assertStringContainsString')
             ? 'assertStringContainsString'
@@ -20,7 +20,7 @@ trait ContentAssertions
 
         $this->{$method}(
             $needle,
-            $mail->getBody(),
+            $mail->getBody()->bodyToString(),
             "The expected [{$needle}] string was not found in the body."
         );
     }
@@ -29,9 +29,9 @@ trait ContentAssertions
      * Assert mail body does not contain string.
      *
      * @param string $needle
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailBodyNotContainsString(string $needle, Swift_Message $mail)
+    public function assertMailBodyNotContainsString(string $needle, Email $mail)
     {
         $method = method_exists($this, 'assertStringNotContainsString')
             ? 'assertStringNotContainsString'
@@ -39,7 +39,7 @@ trait ContentAssertions
 
         $this->{$method}(
             $needle,
-            $mail->getBody(),
+            $mail->getBody()->bodyToString(),
             "The expected [{$needle}] string was found in the body."
         );
     }

--- a/src/Assertions/ContentTypeAssertions.php
+++ b/src/Assertions/ContentTypeAssertions.php
@@ -2,20 +2,21 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\AbstractMultipartPart;
 
 trait ContentTypeAssertions
 {
     /**
      * Assert mail content type is text/plain.
      *
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailIsPlain(Swift_Message $mail)
+    public function assertMailIsPlain(Email $mail)
     {
         $this->assertEquals(
-            'text/plain',
-            $mail->getContentType(),
+            'plain',
+            $mail->getBody()->getMediaSubtype(),
             'The mail is not [text/plain].'
         );
     }
@@ -23,27 +24,63 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not text/plain.
      *
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailIsNotPlain(Swift_Message $mail)
+    public function assertMailIsNotPlain(Email $mail)
     {
         $this->assertNotEquals(
-            'text/plain',
-            $mail->getContentType(),
+            'plain',
+            $mail->getBody()->getMediaSubtype(),
             'The mail is [text/plain].'
+        );
+    }
+
+    /**
+     * Assert multipart email has text/plain content type.
+     *
+     * @param Email $mail
+     */
+    public function assertMailHasPlainContent(Email $mail)
+    {
+        if ($mail->getBody() instanceof AbstractMultipartPart) {
+            $hasPlainContent = collect($mail->getBody()->getParts())
+                ->contains(fn ($part) => $part->getMediaSubtype() === 'plain');
+        }
+
+        $this->assertTrue(
+            $hasPlainContent ?? false,
+            'The mail does not have [text/plain] content.'
+        );
+    }
+
+    /**
+     * Assert multipart email does not have text/plain content type.
+     *
+     * @param Email $mail
+     */
+    public function assertMailDoesNotHavePlainContent(Email $mail)
+    {
+        if ($mail->getBody() instanceof AbstractMultipartPart) {
+            $hasPlainContent = collect($mail->getBody()->getParts())
+                ->contains(fn ($part) => $part->getMediaSubtype() === 'plain');
+        }
+
+        $this->assertFalse(
+            $hasPlainContent ?? true,
+            'The mail does have [text/plain] content.'
         );
     }
 
     /**
      * Assert mail content type is text/html.
      *
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailIsHtml(Swift_Message $mail)
+    public function assertMailIsHtml(Email $mail)
     {
         $this->assertEquals(
-            'text/html',
-            $mail->getContentType(),
+            'html',
+            $mail->getBody()->getMediaSubtype(),
             'The mail is not [text/html].'
         );
     }
@@ -51,29 +88,106 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not text/html.
      *
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailIsNotHtml(Swift_Message $mail)
+    public function assertMailIsNotHtml(Email $mail)
     {
         $this->assertNotEquals(
-            'text/html',
-            $mail->getContentType(),
+            'html',
+            $mail->getBody()->getMediaSubtype(),
             'The mail is [text/html].'
         );
     }
 
-    // /**
-    //  * Assert mail body contains string.
-    //  *
-    //  * @param string $needle
-    //  * @param Swift_Message $mail
-    //  */
-    // public function assertMailBodyNotContainsString(string $needle, Swift_Message $mail)
-    // {
-    //     $this->assertStringNotContainsString(
-    //         $needle,
-    //         $mail->getBody(),
-    //         "The expected [{$needle}] string was found in the body."
-    //     );
-    // }
+    /**
+     * Assert multipart email has text/html content type.
+     *
+     * @param Email $mail
+     */
+    public function assertMailHasHtmlContent(Email $mail)
+    {
+        if ($mail->getBody() instanceof AbstractMultipartPart) {
+            $hasHtmlContent = collect($mail->getBody()->getParts())
+                ->contains(fn ($part) => $part->getMediaSubtype() === 'html');
+        }
+
+        $this->assertTrue(
+            $hasHtmlContent ?? false,
+            'The mail does not have [text/html] content.'
+        );
+    }
+
+    /**
+     * Assert multipart email does not have text/html content type.
+     *
+     * @param Email $mail
+     */
+    public function assertMailDoesNotHaveHtmlContent(Email $mail)
+    {
+        if ($mail->getBody() instanceof AbstractMultipartPart) {
+            $hasHtmlContent = collect($mail->getBody()->getParts())
+                ->contains(fn ($part) => $part->getMediaSubtype() === 'html');
+        }
+
+        $this->assertFalse(
+            $hasHtmlContent ?? true,
+            'The mail does have [text/html] content.'
+        );
+    }
+
+    /**
+     * Assert mail content type is multipart/alternative.
+     *
+     * @param Email $mail
+     */
+    public function assertMailIsAlternative(Email $mail)
+    {
+        $this->assertEquals(
+            'alternative',
+            $mail->getBody()->getMediaSubtype(),
+            'The mail is not [multipart/alternative].'
+        );
+    }
+
+    /**
+     * Assert mail content type is not multipart/alternative.
+     *
+     * @param Email $mail
+     */
+    public function assertMailIsNotAlternative(Email $mail)
+    {
+        $this->assertNotEquals(
+            'alternative',
+            $mail->getBody()->getMediaSubtype(),
+            'The mail is [multipart/alternative].'
+        );
+    }
+
+    /**
+     * Assert mail content type is multipart/mixed.
+     *
+     * @param Email $mail
+     */
+    public function assertMailIsMixed(Email $mail)
+    {
+        $this->assertEquals(
+            'mixed',
+            $mail->getBody()->getMediaSubtype(),
+            'The mail is not [multipart/mixed].'
+        );
+    }
+
+    /**
+     * Assert mail content type is not multipart/mixed.
+     *
+     * @param Email $mail
+     */
+    public function assertMailIsNotMixed(Email $mail)
+    {
+        $this->assertNotEquals(
+            'mixed',
+            $mail->getBody()->getMediaSubtype(),
+            'The mail is [multipart/mixed].'
+        );
+    }
 }

--- a/src/Assertions/FromAssertions.php
+++ b/src/Assertions/FromAssertions.php
@@ -2,25 +2,26 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
 use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait FromAssertions
 {
     /**
      * Assert mail was sent from address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailSentFrom($expected, Swift_Message $mail)
+    public function assertMailSentFrom(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getFrom', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertContains(
                 $address,
-                array_keys($mail->getFrom()),
+                $actualAddresses,
                 "Mail was not sent from the expected address [{$address}]."
             );
         }
@@ -29,17 +30,18 @@ trait FromAssertions
     /**
      * Assert mail was not sent from address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailNotSentFrom($expected, Swift_Message $mail)
+    public function assertMailNotSentFrom(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getFrom', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertNotContains(
                 $address,
-                array_keys($mail->getFrom()),
+                $actualAddresses,
                 "Mail was sent from the expected address [{$address}]."
             );
         }

--- a/src/Assertions/PriorityAssertions.php
+++ b/src/Assertions/PriorityAssertions.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace KirschbaumDevelopment\MailIntercept\Assertions;
+
+use Symfony\Component\Mime\Email;
+
+trait PriorityAssertions
+{
+    /**
+     * Assert mail has priority.
+     *
+     * @param int $expected
+     * @param Email $mail
+     */
+    public function assertMailPriority(int $expected, Email $mail)
+    {
+        $this->assertEquals(
+            $expected,
+            $mail->getPriority(),
+            "The expected priority was not [{$expected}]."
+        );
+    }
+
+    /**
+     * Assert mail does not have priority.
+     *
+     * @param int $expected
+     * @param Email $mail
+     */
+    public function assertMailNotPriority(int $expected, Email $mail)
+    {
+        $this->assertNotEquals(
+            $expected,
+            $mail->getPriority(),
+            "The expected priority was [{$expected}]."
+        );
+    }
+
+    /**
+     * Assert mail has the highest priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityIsHighest(Email $mail)
+    {
+        $this->assertEquals(
+            Email::PRIORITY_HIGHEST,
+            $mail->getPriority(),
+            'The expected priority was not [highest].'
+        );
+    }
+
+    /**
+     * Assert mail does not have the highest priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityNotHighest(Email $mail)
+    {
+        $this->assertNotEquals(
+            Email::PRIORITY_HIGHEST,
+            $mail->getPriority(),
+            'The expected priority was [highest].'
+        );
+    }
+
+    /**
+     * Assert mail has high priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityIsHigh(Email $mail)
+    {
+        $this->assertEquals(
+            Email::PRIORITY_HIGH,
+            $mail->getPriority(),
+            'The expected priority was not [high].'
+        );
+    }
+
+    /**
+     * Assert mail does not have high priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityNotHigh(Email $mail)
+    {
+        $this->assertNotEquals(
+            Email::PRIORITY_HIGH,
+            $mail->getPriority(),
+            'The expected priority was [high].'
+        );
+    }
+
+    /**
+     * Assert mail has normal priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityIsNormal(Email $mail)
+    {
+        $this->assertEquals(
+            Email::PRIORITY_NORMAL,
+            $mail->getPriority(),
+            'The expected priority was not [normal].'
+        );
+    }
+
+    /**
+     * Assert mail does not have normal priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityNotNormal(Email $mail)
+    {
+        $this->assertNotEquals(
+            Email::PRIORITY_NORMAL,
+            $mail->getPriority(),
+            'The expected priority was [normal].'
+        );
+    }
+
+    /**
+     * Assert mail has low priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityIsLow(Email $mail)
+    {
+        $this->assertEquals(
+            Email::PRIORITY_LOW,
+            $mail->getPriority(),
+            'The expected priority was not [low].'
+        );
+    }
+
+    /**
+     * Assert mail does not have low priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityNotLow(Email $mail)
+    {
+        $this->assertNotEquals(
+            Email::PRIORITY_LOW,
+            $mail->getPriority(),
+            'The expected priority was [low].'
+        );
+    }
+
+    /**
+     * Assert mail has the lowest priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityIsLowest(Email $mail)
+    {
+        $this->assertEquals(
+            Email::PRIORITY_LOWEST,
+            $mail->getPriority(),
+            'The expected priority was not [lowest].'
+        );
+    }
+
+    /**
+     * Assert mail does not have the lowest priority.
+     *
+     * @param Email $mail
+     */
+    public function assertMailPriorityNotLowest(Email $mail)
+    {
+        $this->assertNotEquals(
+            Email::PRIORITY_LOWEST,
+            $mail->getPriority(),
+            'The expected priority was [lowest].'
+        );
+    }
+}

--- a/src/Assertions/ReplyToAssertions.php
+++ b/src/Assertions/ReplyToAssertions.php
@@ -2,25 +2,26 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
 use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait ReplyToAssertions
 {
     /**
      * Assert mail replies to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailRepliesTo($expected, Swift_Message $mail)
+    public function assertMailRepliesTo(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getReplyTo', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertContains(
                 $address,
-                array_keys($mail->getReplyTo()),
+                $actualAddresses,
                 "Mail does not reply to the expected address [{$address}]."
             );
         }
@@ -29,17 +30,18 @@ trait ReplyToAssertions
     /**
      * Assert mail does not reply to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailNotRepliesTo($expected, Swift_Message $mail)
+    public function assertMailNotRepliesTo(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getReplyTo', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertNotContains(
                 $address,
-                array_keys($mail->getReplyTo()),
+                $actualAddresses,
                 "Mail replied to the expected address [{$address}]."
             );
         }

--- a/src/Assertions/ReturnPathAssertions.php
+++ b/src/Assertions/ReturnPathAssertions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace KirschbaumDevelopment\MailIntercept\Assertions;
+
+use Symfony\Component\Mime\Email;
+
+trait ReturnPathAssertions
+{
+    /**
+     * Assert mail has return path.
+     *
+     * @param string $expected
+     * @param Email $mail
+     */
+    public function assertMailReturnPath(string $expected, Email $mail)
+    {
+        $this->assertEquals(
+            $expected,
+            $mail->getReturnPath()->getAddress(),
+            "The expected return path was not [{$expected}]."
+        );
+    }
+
+    /**
+     * Assert mail does not have return path.
+     *
+     * @param string $expected
+     * @param Email $mail
+     */
+    public function assertMailNotReturnPath(string $expected, Email $mail)
+    {
+        $this->assertNotEquals(
+            $expected,
+            $mail->getReturnPath()->getAddress(),
+            "The expected return path was [{$expected}]."
+        );
+    }
+}

--- a/src/Assertions/SenderAssertions.php
+++ b/src/Assertions/SenderAssertions.php
@@ -2,46 +2,37 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
-use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait SenderAssertions
 {
     /**
      * Assert mail sender was address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param string $expected
+     * @param Email $mail
      */
-    public function assertMailSender($expected, Swift_Message $mail)
+    public function assertMailSender(string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
-
-        foreach ($addresses as $address) {
-            $this->assertContains(
-                $address,
-                array_keys($mail->getSender()),
-                "Mail sender was not from the expected address [{$address}]."
-            );
-        }
+        $this->assertEquals(
+            $expected,
+            $mail->getSender()->getAddress(),
+            "Mail sender was not from the expected address [{$expected}]."
+        );
     }
 
     /**
      * Assert mail was not sender address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param string $expected
+     * @param Email $mail
      */
-    public function assertMailNotSender($expected, Swift_Message $mail)
+    public function assertMailNotSender(string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
-
-        foreach ($addresses as $address) {
-            $this->assertNotContains(
-                $address,
-                array_keys($mail->getSender()),
-                "Mail sender was from the expected address [{$address}]."
-            );
-        }
+        $this->assertNotEquals(
+            $expected,
+            $mail->getSender()->getAddress(),
+            "Mail sender was from the expected address [{$expected}]."
+        );
     }
 }

--- a/src/Assertions/SubjectAssertions.php
+++ b/src/Assertions/SubjectAssertions.php
@@ -2,7 +2,7 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
+use Symfony\Component\Mime\Email;
 
 trait SubjectAssertions
 {
@@ -10,9 +10,9 @@ trait SubjectAssertions
      * Assert mail has subject.
      *
      * @param string $expected
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailSubject(string $expected, Swift_Message $mail)
+    public function assertMailSubject(string $expected, Email $mail)
     {
         $this->assertEquals(
             $expected,
@@ -25,9 +25,9 @@ trait SubjectAssertions
      * Assert mail does not have subject.
      *
      * @param string $expected
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailNotSubject(string $expected, Swift_Message $mail)
+    public function assertMailNotSubject(string $expected, Email $mail)
     {
         $this->assertNotEquals(
             $expected,

--- a/src/Assertions/ToAssertions.php
+++ b/src/Assertions/ToAssertions.php
@@ -2,25 +2,26 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
 use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Email;
 
 trait ToAssertions
 {
     /**
      * Assert mail was sent to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailSentTo($expected, Swift_Message $mail)
+    public function assertMailSentTo(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getTo', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertContains(
                 $address,
-                array_keys($mail->getTo()),
+                $actualAddresses,
                 "Mail was not sent to the expected address [{$address}]."
             );
         }
@@ -29,17 +30,18 @@ trait ToAssertions
     /**
      * Assert mail was not sent to address.
      *
-     * @param string|array $expected
-     * @param Swift_Message $mail
+     * @param array|string $expected
+     * @param Email $mail
      */
-    public function assertMailNotSentTo($expected, Swift_Message $mail)
+    public function assertMailNotSentTo(array|string $expected, Email $mail)
     {
-        $addresses = Arr::wrap($expected);
+        $expectedAddresses = Arr::wrap($expected);
+        $actualAddresses = $this->gatherEmailData('getTo', $mail);
 
-        foreach ($addresses as $address) {
+        foreach ($expectedAddresses as $address) {
             $this->assertNotContains(
                 $address,
-                array_keys($mail->getTo()),
+                $actualAddresses,
                 "Mail was sent to the expected address [{$address}]."
             );
         }

--- a/src/Assertions/ToAssertions.php
+++ b/src/Assertions/ToAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Illuminate\Support\Arr;
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ToAssertions
 {
@@ -11,9 +12,9 @@ trait ToAssertions
      * Assert mail was sent to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailSentTo(array|string $expected, Email $mail)
+    public function assertMailSentTo(array|string $expected, AssertableMessage|Email $mail)
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getTo', $mail);
@@ -31,9 +32,9 @@ trait ToAssertions
      * Assert mail was not sent to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotSentTo(array|string $expected, Email $mail)
+    public function assertMailNotSentTo(array|string $expected, AssertableMessage|Email $mail)
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getTo', $mail);

--- a/src/Assertions/UnstructuredHeaderAssertions.php
+++ b/src/Assertions/UnstructuredHeaderAssertions.php
@@ -2,8 +2,8 @@
 
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
-use Swift_Message;
-use Swift_Mime_Header;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 trait UnstructuredHeaderAssertions
 {
@@ -11,12 +11,12 @@ trait UnstructuredHeaderAssertions
      * Assert unstructured header exists.
      *
      * @param string $expected
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailHasHeader(string $expected, Swift_Message $mail)
+    public function assertMailHasHeader(string $expected, Email $mail)
     {
         $this->assertInstanceOf(
-            Swift_Mime_Header::class,
+            UnstructuredHeader::class,
             $mail->getHeaders()->get($expected),
             "The expected [{$expected}] header did not exist."
         );
@@ -26,9 +26,9 @@ trait UnstructuredHeaderAssertions
      * Assert unstructured header exists.
      *
      * @param string $expected
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailMissingHeader(string $expected, Swift_Message $mail)
+    public function assertMailMissingHeader(string $expected, Email $mail)
     {
         $this->assertNull(
             $mail->getHeaders()->get($expected),
@@ -41,9 +41,9 @@ trait UnstructuredHeaderAssertions
      *
      * @param string $expected
      * @param string $expectedValue
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailHeaderIs(string $expected, string $expectedValue, Swift_Message $mail)
+    public function assertMailHeaderIs(string $expected, string $expectedValue, Email $mail)
     {
         $this->assertEquals(
             $expectedValue,
@@ -57,9 +57,9 @@ trait UnstructuredHeaderAssertions
      *
      * @param string $expected
      * @param string $expectedValue
-     * @param Swift_Message $mail
+     * @param Email $mail
      */
-    public function assertMailHeaderIsNot(string $expected, string $expectedValue, Swift_Message $mail)
+    public function assertMailHeaderIsNot(string $expected, string $expectedValue, Email $mail)
     {
         $this->assertNotEquals(
             $expectedValue,

--- a/tests/BccAssertionsTest.php
+++ b/tests/BccAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\BccAssertions;
 
 class BccAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use BccAssertions;
-
     public function testMailBccSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setBcc($email);
+        $mail = (new Email())->bcc($email);
 
         $this->assertMailBcc($email, $mail);
     }
@@ -25,7 +20,7 @@ class BccAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setBcc($this->faker->unique->email);
+        $mail = (new Email())->bcc($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was not BCC'd to the expected address [{$email}].");
@@ -40,7 +35,7 @@ class BccAssertionsTest extends TestCase
             $this->faker->email,
         ];
 
-        $mail = (new Swift_Message())->setBcc($emails);
+        $mail = (new Email())->bcc(...$emails);
 
         $this->assertMailBcc($emails, $mail);
     }
@@ -49,7 +44,7 @@ class BccAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setBcc($this->faker->unique()->email);
+        $mail = (new Email())->bcc($this->faker->unique()->email);
 
         $this->assertMailNotBcc($email, $mail);
     }
@@ -58,7 +53,7 @@ class BccAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setBcc($email);
+        $mail = (new Email())->bcc($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was BCC'd to the expected address [{$email}].");
@@ -73,10 +68,10 @@ class BccAssertionsTest extends TestCase
             $this->faker->unique()->email,
         ];
 
-        $mail = (new Swift_Message())->setBcc([
+        $mail = (new Email())->bcc(
             $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
+            $this->faker->unique()->email
+        );
 
         $this->assertMailNotBcc($emails, $mail);
     }

--- a/tests/CcAssertionsTest.php
+++ b/tests/CcAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\CcAssertions;
 
 class CcAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use CcAssertions;
-
     public function testMailCcSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setCc($email);
+        $mail = (new Email())->cc($email);
 
         $this->assertMailCc($email, $mail);
     }
@@ -25,7 +20,7 @@ class CcAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setCc($this->faker->unique->email);
+        $mail = (new Email())->cc($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was not CC'd to the expected address [{$email}].");
@@ -40,7 +35,7 @@ class CcAssertionsTest extends TestCase
             $this->faker->email,
         ];
 
-        $mail = (new Swift_Message())->setCc($emails);
+        $mail = (new Email())->cc(...$emails);
 
         $this->assertMailCc($emails, $mail);
     }
@@ -49,7 +44,7 @@ class CcAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setCc($this->faker->unique()->email);
+        $mail = (new Email())->cc($this->faker->unique()->email);
 
         $this->assertMailNotCc($email, $mail);
     }
@@ -58,7 +53,7 @@ class CcAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setCc($email);
+        $mail = (new Email())->cc($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was CC'd to the expected address [{$email}].");
@@ -73,10 +68,10 @@ class CcAssertionsTest extends TestCase
             $this->faker->unique()->email,
         ];
 
-        $mail = (new Swift_Message())->setCc([
+        $mail = (new Email())->cc(
             $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
+            $this->faker->unique()->email
+        );
 
         $this->assertMailNotCc($emails, $mail);
     }

--- a/tests/ContentAssertionsTest.php
+++ b/tests/ContentAssertionsTest.php
@@ -2,30 +2,32 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\TextPart;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\ContentAssertions;
 
 class ContentAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use ContentAssertions;
-
-    public function testMailBodyContents()
+    public function testMailBodyContentsAsText()
     {
         $content = $this->faker->sentence;
 
-        $mail = (new Swift_Message())->setBody($content);
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($content);
 
         $this->assertMailBodyContainsString($content, $mail);
     }
 
-    public function testMailBodyContentsThrowsProperExpectationFailedException()
+    public function testMailBodyContentsAsTextThrowsProperExpectationFailedException()
     {
         $content = $this->faker->unique()->sentence;
 
-        $mail = (new Swift_Message())->setBody($this->faker->unique()->sentence);
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->unique()->sentence);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
@@ -33,20 +35,126 @@ class ContentAssertionsTest extends TestCase
         $this->assertMailBodyContainsString($content, $mail);
     }
 
-    public function testMailBodyDoesNotHaveContents()
+    public function testMailBodyAsTextDoesNotHaveContents()
     {
         $content = $this->faker->unique()->sentence;
 
-        $mail = (new Swift_Message())->setBody($this->faker->unique()->sentence);
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->unique()->sentence);
 
         $this->assertMailBodyNotContainsString($content, $mail);
     }
 
-    public function testMailBodyDoesNotHaveContentsThrowsProperExpectationFailedException()
+    public function testMailBodyAsTextDoesNotHaveContentsThrowsProperExpectationFailedException()
     {
         $content = $this->faker->sentence;
 
-        $mail = (new Swift_Message())->setBody($content);
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($content);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsHtml()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($content);
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsHtmlThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($this->faker->unique()->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsHtmlDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($this->faker->unique()->sentence);
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsHtmlDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($content);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsAbstractPart()
+    {
+        $content = $this->faker->sentence;
+        $textPart = new TextPart($content);
+
+        $mail = (new Email())->setBody($textPart);
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsAbstractPartThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+        $textPart = new TextPart($this->faker->unique()->sentence);
+
+        $mail = (new Email())->setBody($textPart);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsAbstractPartDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+        $textPart = new TextPart($this->faker->unique()->sentence);
+
+        $mail = (new Email())->setBody($textPart);
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsAbstractPartDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+        $textPart = new TextPart($content);
+
+        $mail = (new Email())->setBody($textPart);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");

--- a/tests/ContentTypeAssertionsTest.php
+++ b/tests/ContentTypeAssertionsTest.php
@@ -2,26 +2,26 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\TextPart;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\ContentTypeAssertions;
 
 class ContentTypeAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use ContentTypeAssertions;
-
     public function testMailContentTypePlain()
     {
-        $mail = new Swift_Message();
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence);
 
         $this->assertMailIsPlain($mail);
     }
 
     public function testMailContentTypePlainThrowsException()
     {
-        $mail = (new Swift_Message())->setContentType('text/bad');
+        $part = new TextPart('body', subtype: 'bad');
+        $mail = (new Email())->setBody($part);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The mail is not [text/plain].');
@@ -31,14 +31,18 @@ class ContentTypeAssertionsTest extends TestCase
 
     public function testMailContentTypeNotPlain()
     {
-        $mail = (new Swift_Message())->setContentType('text/not-plain');
+        $part = new TextPart('body', subtype: 'not-plain');
+        $mail = (new Email())->setBody($part);
 
         $this->assertMailIsNotPlain($mail);
     }
 
     public function testMailContentTypeNotPlainThrowsException()
     {
-        $mail = new Swift_Message();
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The mail is [text/plain].');
@@ -46,16 +50,70 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsNotPlain($mail);
     }
 
+    public function testMailHasPlainContent()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->assertMailHasPlainContent($mail);
+    }
+
+    public function testMailHasPlainContentThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->html($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does not have [text/plain] content.');
+
+        $this->assertMailHasPlainContent($mail);
+    }
+
+    public function testMailDoesNotHavePlainContent()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->html($this->faker->sentence);
+
+        $this->assertMailDoesNotHavePlainContent($mail);
+    }
+
+    public function testMailDoesNotHavePlainContentThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does have [text/plain] content.');
+
+        $this->assertMailDoesNotHavePlainContent($mail);
+    }
+
     public function testMailContentTypeHtml()
     {
-        $mail = (new Swift_Message())->setContentType('text/html');
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($this->faker->sentence);
 
         $this->assertMailIsHtml($mail);
     }
 
     public function testMailContentTypeHtmlThrowsException()
     {
-        $mail = (new Swift_Message())->setContentType('text/bad');
+        $part = new TextPart('body', subtype: 'bad');
+        $mail = (new Email())->setBody($part);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The mail is not [text/html].');
@@ -65,18 +123,160 @@ class ContentTypeAssertionsTest extends TestCase
 
     public function testMailContentTypeNotHtml()
     {
-        $mail = (new Swift_Message())->setContentType('text/not-html');
+        $part = new TextPart('body', subtype: 'not-html');
+        $mail = (new Email())->setBody($part);
 
         $this->assertMailIsNotHtml($mail);
     }
 
     public function testMailContentTypeNotHtmlThrowsException()
     {
-        $mail = (new Swift_Message())->setContentType('text/html');
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->html($this->faker->sentence);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The mail is [text/html].');
 
         $this->assertMailIsNotHtml($mail);
+    }
+
+    public function testMailHasHtmlContent()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->assertMailHasHtmlContent($mail);
+    }
+
+    public function testMailHasHtmlContentThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->text($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does not have [text/html] content.');
+
+        $this->assertMailHasHtmlContent($mail);
+    }
+
+    public function testMailDoesNotHaveHtmlContent()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->text($this->faker->sentence);
+
+        $this->assertMailDoesNotHaveHtmlContent($mail);
+    }
+
+    public function testMailDoesNotHaveHtmlContentThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does have [text/html] content.');
+
+        $this->assertMailDoesNotHaveHtmlContent($mail);
+    }
+
+    public function testMailContentTypeAlternative()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->assertMailIsAlternative($mail);
+    }
+
+    public function testMailContentTypeAlternativeThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'not-alternative');
+        $mail = (new Email())->setBody($part);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [multipart/alternative].');
+
+        $this->assertMailIsAlternative($mail);
+    }
+
+    public function testMailContentTypeNotAlternative()
+    {
+        $part = new TextPart('body', subtype: 'not-alternative');
+        $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotAlternative($mail);
+    }
+
+    public function testMailContentTypeNotAlternativeThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->sentence)
+            ->html($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [multipart/alternative].');
+
+        $this->assertMailIsNotAlternative($mail);
+    }
+
+    public function testMailContentTypeMixed()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->text($this->faker->sentence);
+
+        $this->assertMailIsMixed($mail);
+    }
+
+    public function testMailContentTypeMixedThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'not-mixed');
+        $mail = (new Email())->setBody($part);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [multipart/mixed].');
+
+        $this->assertMailIsMixed($mail);
+    }
+
+    public function testMailContentTypeNotMixed()
+    {
+        $part = new TextPart('body', subtype: 'not-mixed');
+        $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotMixed($mail);
+    }
+
+    public function testMailContentTypeNotMixedThrowsException()
+    {
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->attach('attachment')
+            ->text($this->faker->sentence);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [multipart/mixed].');
+
+        $this->assertMailIsNotMixed($mail);
     }
 }

--- a/tests/Fluent/BccAssertionsTest.php
+++ b/tests/Fluent/BccAssertionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class BccAssertionsTest extends TestCase
+{
+    public function testMailBccSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($email)
+        );
+
+        $mail->assertBcc($email);
+    }
+
+    public function testMailBccThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was not BCC'd to the expected address [{$email}].");
+
+        $mail->assertBcc($email);
+    }
+
+    public function testMailSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->email,
+            $this->faker->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc(...$emails)
+        );
+
+        $mail->assertBcc($emails);
+    }
+
+    public function testMailNotSentToSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($this->faker->unique()->email)
+        );
+
+        $mail->assertNotBcc($email);
+    }
+
+    public function testMailNotSentToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was BCC'd to the expected address [{$email}].");
+
+        $mail->assertNotBcc($email);
+    }
+
+    public function testMailNotSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->unique()->email,
+            $this->faker->unique()->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc(
+                $this->faker->unique()->email,
+                $this->faker->unique()->email
+            )
+        );
+
+        $mail->assertNotBcc($emails);
+    }
+}

--- a/tests/Fluent/CcAssertionsTest.php
+++ b/tests/Fluent/CcAssertionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class CcAssertionsTest extends TestCase
+{
+    public function testMailCcSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($email)
+        );
+
+        $mail->assertCc($email);
+    }
+
+    public function testMailCcThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was not CC'd to the expected address [{$email}].");
+
+        $mail->assertCc($email);
+    }
+
+    public function testMailSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->email,
+            $this->faker->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->cc(...$emails)
+        );
+
+        $mail->assertCc($emails);
+    }
+
+    public function testMailNotSentToSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($this->faker->unique()->email)
+        );
+
+        $mail->assertNotCc($email);
+    }
+
+    public function testMailNotSentToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was CC'd to the expected address [{$email}].");
+
+        $mail->assertNotCc($email);
+    }
+
+    public function testMailNotSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->unique()->email,
+            $this->faker->unique()->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->cc(
+                $this->faker->unique()->email,
+                $this->faker->unique()->email
+            )
+        );
+
+        $mail->assertNotCc($emails);
+    }
+}

--- a/tests/Fluent/ContentAssertionsTest.php
+++ b/tests/Fluent/ContentAssertionsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\TextPart;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class ContentAssertionsTest extends TestCase
+{
+    public function testMailBodyContentsAsText()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($content)
+        );
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyContentsAsTextThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->unique()->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyAsTextDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->unique()->sentence)
+        );
+
+        $mail->assertBodyNotContainsString($content);
+    }
+
+    public function testMailBodyAsTextDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($content)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $mail->assertBodyNotContainsString($content);
+    }
+
+    public function testMailBodyContentsAsHtml()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($content)
+        );
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyContentsAsHtmlThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($this->faker->unique()->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyAsHtmlDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($this->faker->unique()->sentence)
+        );
+
+        $mail->assertBodyNotContainsString($content);
+    }
+
+    public function testMailBodyAsHtmlDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($content)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $mail->assertBodyNotContainsString($content);
+    }
+
+    public function testMailBodyContentsAsAbstractPart()
+    {
+        $content = $this->faker->sentence;
+        $textPart = new TextPart($content);
+
+        $mail = new AssertableMessage(
+            (new Email())->setBody($textPart)
+        );
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyContentsAsAbstractPartThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+        $textPart = new TextPart($this->faker->unique()->sentence);
+
+        $mail = new AssertableMessage(
+            (new Email())->setBody($textPart)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $mail->assertBodyContainsString($content);
+    }
+
+    public function testMailBodyAsAbstractPartDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+        $textPart = new TextPart($this->faker->unique()->sentence);
+
+        $mail = new AssertableMessage(
+            (new Email())->setBody($textPart)
+        );
+
+        $mail->assertBodyNotContainsString($content);
+    }
+
+    public function testMailBodyAsAbstractPartDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+        $textPart = new TextPart($content);
+
+        $mail = new AssertableMessage(
+            (new Email())->setBody($textPart)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $mail->assertBodyNotContainsString($content);
+    }
+}

--- a/tests/Fluent/ContentTypeAssertionsTest.php
+++ b/tests/Fluent/ContentTypeAssertionsTest.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\TextPart;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class ContentTypeAssertionsTest extends TestCase
+{
+    public function testMailContentTypePlain()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+        );
+
+        $mail->assertIsPlain();
+    }
+
+    public function testMailContentTypePlainThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'bad');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [text/plain].');
+
+        $mail->assertIsPlain();
+    }
+
+    public function testMailContentTypeNotPlain()
+    {
+        $part = new TextPart('body', subtype: 'not-plain');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $mail->assertIsNotPlain();
+    }
+
+    public function testMailContentTypeNotPlainThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [text/plain].');
+
+        $mail->assertIsNotPlain();
+    }
+
+    public function testMailHasPlainContent()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $mail->assertHasPlainContent();
+    }
+
+    public function testMailHasPlainContentThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->html($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does not have [text/plain] content.');
+
+        $mail->assertHasPlainContent();
+    }
+
+    public function testMailDoesNotHavePlainContent()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->html($this->faker->sentence)
+        );
+
+        $mail->assertDoesNotHavePlainContent();
+    }
+
+    public function testMailDoesNotHavePlainContentThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does have [text/plain] content.');
+
+        $mail->assertDoesNotHavePlainContent();
+    }
+
+    public function testMailContentTypeHtml()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($this->faker->sentence)
+        );
+
+        $mail->assertIsHtml();
+    }
+
+    public function testMailContentTypeHtmlThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'bad');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [text/html].');
+
+        $mail->assertIsHtml();
+    }
+
+    public function testMailContentTypeNotHtml()
+    {
+        $part = new TextPart('body', subtype: 'not-html');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $mail->assertIsNotHtml();
+    }
+
+    public function testMailContentTypeNotHtmlThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [text/html].');
+
+        $mail->assertIsNotHtml();
+    }
+
+    public function testMailHasHtmlContent()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $mail->assertHasHtmlContent();
+    }
+
+    public function testMailHasHtmlContentThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does not have [text/html] content.');
+
+        $mail->assertHasHtmlContent();
+    }
+
+    public function testMailDoesNotHaveHtmlContent()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
+
+        $mail->assertDoesNotHaveHtmlContent();
+    }
+
+    public function testMailDoesNotHaveHtmlContentThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail does have [text/html] content.');
+
+        $mail->assertDoesNotHaveHtmlContent();
+    }
+
+    public function testMailContentTypeAlternative()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $mail->assertIsAlternative();
+    }
+
+    public function testMailContentTypeAlternativeThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'not-alternative');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [multipart/alternative].');
+
+        $mail->assertIsAlternative();
+    }
+
+    public function testMailContentTypeNotAlternative()
+    {
+        $part = new TextPart('body', subtype: 'not-alternative');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $mail->assertIsNotAlternative();
+    }
+
+    public function testMailContentTypeNotAlternativeThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [multipart/alternative].');
+
+        $mail->assertIsNotAlternative();
+    }
+
+    public function testMailContentTypeMixed()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
+
+        $mail->assertIsMixed();
+    }
+
+    public function testMailContentTypeMixedThrowsException()
+    {
+        $part = new TextPart('body', subtype: 'not-mixed');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is not [multipart/mixed].');
+
+        $mail->assertIsMixed();
+    }
+
+    public function testMailContentTypeNotMixed()
+    {
+        $part = new TextPart('body', subtype: 'not-mixed');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
+
+        $mail->assertIsNotMixed();
+    }
+
+    public function testMailContentTypeNotMixedThrowsException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The mail is [multipart/mixed].');
+
+        $mail->assertIsNotMixed();
+    }
+}

--- a/tests/Fluent/FromAssertionsTest.php
+++ b/tests/Fluent/FromAssertionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class FromAssertionsTest extends TestCase
+{
+    public function testMailSentFromSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($email)
+        );
+
+        $mail->assertSentFrom($email);
+    }
+
+    public function testMailSentFromThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was not sent from the expected address [{$email}].");
+
+        $mail->assertSentFrom($email);
+    }
+
+    public function testMailSentFromMultipleEmails()
+    {
+        $emails = [
+            $this->faker->email,
+            $this->faker->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->from(...$emails)
+        );
+
+        $mail->assertSentFrom($emails);
+    }
+
+    public function testMailNotSentFromSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($this->faker->unique()->email)
+        );
+
+        $mail->assertNotSentFrom($email);
+    }
+
+    public function testMailNotSentFromThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was sent from the expected address [{$email}].");
+
+        $mail->assertNotSentFrom($email);
+    }
+
+    public function testMailNotSentFromMultipleEmails()
+    {
+        $emails = [
+            $this->faker->unique()->email,
+            $this->faker->unique()->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->from(
+                $this->faker->unique()->email,
+                $this->faker->unique()->email
+            )
+        );
+
+        $mail->assertNotSentFrom($emails);
+    }
+}

--- a/tests/Fluent/PriorityAssertionsTest.php
+++ b/tests/Fluent/PriorityAssertionsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class PriorityAssertionsTest extends TestCase
+{
+    public function testMailPrioritySingleEmail()
+    {
+        $priority = mt_rand(1, 5);
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($priority)
+        );
+
+        $mail->assertPriority($priority);
+    }
+
+    public function testMailPriorityThrowsProperExpectationFailedException()
+    {
+        $priorities = collect(range(1, 5))->shuffle();
+        $actualPriority = $priorities->pop();
+        $expectedPriority = $priorities->random();
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($actualPriority)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected priority was not [{$expectedPriority}].");
+
+        $mail->assertPriority($expectedPriority);
+    }
+
+    public function testMailNotPrioritySingleEmail()
+    {
+        $priorities = collect(range(1, 5))->shuffle();
+        $actualPriority = $priorities->pop();
+        $expectedPriority = $priorities->random();
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($actualPriority)
+        );
+
+        $mail->assertNotPriority($expectedPriority);
+    }
+
+    public function testMailNotPriorityThrowsProperExpectationFailedException()
+    {
+        $priority = mt_rand(1, 5);
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($priority)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected priority was [{$priority}].");
+
+        $mail->assertNotPriority($priority);
+    }
+
+    public function testMailPriorityHighest()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGHEST)
+        );
+
+        $mail->assertPriorityIsHighest();
+    }
+
+    public function testMailPriorityHighestThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [highest].');
+
+        $mail->assertPriorityIsHighest();
+    }
+
+    public function testMailPriorityNotHighest()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $mail->assertPriorityNotHighest();
+    }
+
+    public function testMailPriorityNotHighestThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGHEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [highest].');
+
+        $mail->assertPriorityNotHighest();
+    }
+
+    public function testMailPriorityHigh()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGH)
+        );
+
+        $mail->assertPriorityIsHigh();
+    }
+
+    public function testMailPriorityHighThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [high].');
+
+        $mail->assertPriorityIsHigh();
+    }
+
+    public function testMailPriorityNotHigh()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $mail->assertPriorityNotHigh();
+    }
+
+    public function testMailPriorityNotHighThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGH)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [high].');
+
+        $mail->assertPriorityNotHigh();
+    }
+
+    public function testMailPriorityNormal()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_NORMAL)
+        );
+
+        $mail->assertPriorityIsNormal();
+    }
+
+    public function testMailPriorityNormalThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [normal].');
+
+        $mail->assertPriorityIsNormal();
+    }
+
+    public function testMailPriorityNotNormal()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $mail->assertPriorityNotNormal();
+    }
+
+    public function testMailPriorityNotNormalThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_NORMAL)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [normal].');
+
+        $mail->assertPriorityNotNormal();
+    }
+
+    public function testMailPriorityLow()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
+
+        $mail->assertPriorityIsLow();
+    }
+
+    public function testMailPriorityLowThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [low].');
+
+        $mail->assertPriorityIsLow();
+    }
+
+    public function testMailPriorityNotLow()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $mail->assertPriorityNotLow();
+    }
+
+    public function testMailPriorityNotLowThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [low].');
+
+        $mail->assertPriorityNotLow();
+    }
+
+    public function testMailPriorityLowest()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $mail->assertPriorityIsLowest();
+    }
+
+    public function testMailPriorityLowestThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [lowest].');
+
+        $mail->assertPriorityIsLowest();
+    }
+
+    public function testMailPriorityNotLowest()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
+
+        $mail->assertPriorityNotLowest();
+    }
+
+    public function testMailPriorityNotLowestThrowsProperExpectationFailedException()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [lowest].');
+
+        $mail->assertPriorityNotLowest();
+    }
+}

--- a/tests/Fluent/ReplyToAssertionsTest.php
+++ b/tests/Fluent/ReplyToAssertionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class ReplyToAssertionsTest extends TestCase
+{
+    public function testMailRepliesToSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($email)
+        );
+
+        $mail->assertRepliesTo($email);
+    }
+
+    public function testMailRepliesToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail does not reply to the expected address [{$email}].");
+
+        $mail->assertRepliesTo($email);
+    }
+
+    public function testMailRepliesToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->email,
+            $this->faker->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo(...$emails)
+        );
+
+        $mail->assertRepliesTo($emails);
+    }
+
+    public function testMailNotRepliesToSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($this->faker->unique()->email)
+        );
+
+        $mail->assertNotRepliesTo($email);
+    }
+
+    public function testMailNotRepliesToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail replied to the expected address [{$email}].");
+
+        $mail->assertNotRepliesTo($email);
+    }
+
+    public function testMailNotRepliesToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->unique()->email,
+            $this->faker->unique()->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo(
+                $this->faker->unique()->email,
+                $this->faker->unique()->email
+            )
+        );
+
+        $mail->assertNotRepliesTo($emails);
+    }
+}

--- a/tests/Fluent/ReturnPathAssertionsTest.php
+++ b/tests/Fluent/ReturnPathAssertionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class ReturnPathAssertionsTest extends TestCase
+{
+    public function testMailReturnPathSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($email)
+        );
+
+        $mail->assertReturnPath($email);
+    }
+
+    public function testMailReturnPathThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected return path was not [{$email}].");
+
+        $mail->assertReturnPath($email);
+    }
+
+    public function testMailNotReturnPathSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($this->faker->unique()->email)
+        );
+
+        $mail->assertNotReturnPath($email);
+    }
+
+    public function testMailNotReturnPathThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected return path was [{$email}].");
+
+        $mail->assertNotReturnPath($email);
+    }
+}

--- a/tests/Fluent/SenderAssertionsTest.php
+++ b/tests/Fluent/SenderAssertionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class SenderAssertionsTest extends TestCase
+{
+    public function testMailSenderSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($email)
+        );
+
+        $mail->assertSender($email);
+    }
+
+    public function testMailSenderThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail sender was not from the expected address [{$email}].");
+
+        $mail->assertSender($email);
+    }
+
+    public function testMailNotSenderSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($this->faker->unique()->email)
+        );
+
+        $mail->assertNotSender($email);
+    }
+
+    public function testMailNotSenderThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail sender was from the expected address [{$email}].");
+
+        $mail->assertNotSender($email);
+    }
+}

--- a/tests/Fluent/SubjectAssertionsTest.php
+++ b/tests/Fluent/SubjectAssertionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class SubjectAssertionsTest extends TestCase
+{
+    public function testMailSubject()
+    {
+        $subject = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($subject)
+        );
+
+        $mail->assertSubject($subject);
+    }
+
+    public function testMailSubjectThrowsProperExpectationFailedException()
+    {
+        $subject = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($this->faker->unique()->sentence)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected subject was not [{$subject}].");
+
+        $mail->assertSubject($subject);
+    }
+
+    public function testMailNotSubject()
+    {
+        $subject = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($this->faker->unique()->sentence)
+        );
+
+        $mail->assertNotSubject($subject);
+    }
+
+    public function testMailNotSubjectThrowsProperExpectationFailedException()
+    {
+        $subject = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($subject)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected subject was [{$subject}].");
+
+        $mail->assertNotSubject($subject);
+    }
+}

--- a/tests/Fluent/ToAssertionsTest.php
+++ b/tests/Fluent/ToAssertionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Fluent;
+
+use Tests\TestCase;
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
+
+class ToAssertionsTest extends TestCase
+{
+    public function testMailSentToSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($email)
+        );
+
+        $mail->assertSentTo($email);
+    }
+
+    public function testMailSentToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($this->faker->unique()->email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was not sent to the expected address [{$email}].");
+
+        $mail->assertSentTo($email);
+    }
+
+    public function testMailSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->email,
+            $this->faker->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->to(...$emails)
+        );
+
+        $mail->assertSentTo($emails);
+    }
+
+    public function testMailNotSentToSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($this->faker->unique()->email)
+        );
+
+        $mail->assertNotSentTo($email);
+    }
+
+    public function testMailNotSentToThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($email)
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Mail was sent to the expected address [{$email}].");
+
+        $mail->assertNotSentTo($email);
+    }
+
+    public function testMailNotSentToMultipleEmails()
+    {
+        $emails = [
+            $this->faker->unique()->email,
+            $this->faker->unique()->email,
+        ];
+
+        $mail = new AssertableMessage(
+            (new Email())->to(
+                $this->faker->unique()->email,
+                $this->faker->unique()->email
+            )
+        );
+
+        $mail->assertNotSentTo($emails);
+    }
+}

--- a/tests/Fluent/UnstructuredHeaderAssertionsTest.php
+++ b/tests/Fluent/UnstructuredHeaderAssertionsTest.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace Tests;
+namespace Tests\Fluent;
 
+use Tests\TestCase;
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class UnstructuredHeaderAssertionsTest extends TestCase
 {
@@ -14,7 +16,9 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->word);
 
-        $this->assertMailHasHeader($header, $mail);
+        $mail = new AssertableMessage($mail);
+
+        $mail->assertHasHeader($header);
     }
 
     public function testMailHasHeaderThrowsProperExpectationFailedException()
@@ -24,10 +28,12 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
 
+        $mail = new AssertableMessage($mail);
+
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$header}] header did not exist.");
 
-        $this->assertMailHasHeader($header, $mail);
+        $mail->assertHasHeader($header);
     }
 
     public function testMailMissingHeader()
@@ -37,7 +43,9 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
 
-        $this->assertMailMissingHeader($header, $mail);
+        $mail = new AssertableMessage($mail);
+
+        $mail->assertMissingHeader($header);
     }
 
     public function testMailMissingHeaderThrowsProperExpectationFailedException()
@@ -47,10 +55,12 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->word);
 
+        $mail = new AssertableMessage($mail);
+
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$header}] header did exist.");
 
-        $this->assertMailMissingHeader($header, $mail);
+        $mail->assertMissingHeader($header);
     }
 
     public function testMailHeaderIs()
@@ -61,7 +71,9 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $value);
 
-        $this->assertMailHeaderIs($header, $value, $mail);
+        $mail = new AssertableMessage($mail);
+
+        $mail->assertHeaderIs($header, $value);
     }
 
     public function testMailHeaderIsThrowsProperExpectationFailedException()
@@ -72,10 +84,12 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
 
+        $mail = new AssertableMessage($mail);
+
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$header}] was not set to [{$value}].");
 
-        $this->assertMailHeaderIs($header, $value, $mail);
+        $mail->assertHeaderIs($header, $value);
     }
 
     public function testMailHeaderIsNot()
@@ -86,7 +100,9 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
 
-        $this->assertMailHeaderIsNot($header, $value, $mail);
+        $mail = new AssertableMessage($mail);
+
+        $mail->assertHeaderIsNot($header, $value);
     }
 
     public function testMailHeaderIsNotThrowsProperExpectationFailedException()
@@ -97,9 +113,11 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $value);
 
+        $mail = new AssertableMessage($mail);
+
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected [{$header}] was set to [{$value}].");
 
-        $this->assertMailHeaderIsNot($header, $value, $mail);
+        $mail->assertHeaderIsNot($header, $value);
     }
 }

--- a/tests/FromAssertionsTest.php
+++ b/tests/FromAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\FromAssertions;
 
 class FromAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use FromAssertions;
-
     public function testMailSentFromSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setFrom($email);
+        $mail = (new Email())->from($email);
 
         $this->assertMailSentFrom($email, $mail);
     }
@@ -25,7 +20,7 @@ class FromAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setFrom($this->faker->unique->email);
+        $mail = (new Email())->from($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was not sent from the expected address [{$email}].");
@@ -40,7 +35,7 @@ class FromAssertionsTest extends TestCase
             $this->faker->email,
         ];
 
-        $mail = (new Swift_Message())->setFrom($emails);
+        $mail = (new Email())->from(...$emails);
 
         $this->assertMailSentFrom($emails, $mail);
     }
@@ -49,7 +44,7 @@ class FromAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setFrom($this->faker->unique()->email);
+        $mail = (new Email())->from($this->faker->unique()->email);
 
         $this->assertMailNotSentFrom($email, $mail);
     }
@@ -58,7 +53,7 @@ class FromAssertionsTest extends TestCase
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setFrom($email);
+        $mail = (new Email())->from($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was sent from the expected address [{$email}].");
@@ -73,10 +68,10 @@ class FromAssertionsTest extends TestCase
             $this->faker->unique()->email,
         ];
 
-        $mail = (new Swift_Message())->setFrom([
+        $mail = (new Email())->from(
             $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
+            $this->faker->unique()->email
+        );
 
         $this->assertMailNotSentFrom($emails, $mail);
     }

--- a/tests/PriorityAssertionsTest.php
+++ b/tests/PriorityAssertionsTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests;
+
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class PriorityAssertionsTest extends TestCase
+{
+    public function testMailPrioritySingleEmail()
+    {
+        $priority = mt_rand(1, 5);
+
+        $mail = (new Email())->priority($priority);
+
+        $this->assertMailPriority($priority, $mail);
+    }
+
+    public function testMailPriorityThrowsProperExpectationFailedException()
+    {
+        $priorities = collect(range(1, 5))->shuffle();
+        $actualPriority = $priorities->pop();
+        $expectedPriority = $priorities->random();
+
+        $mail = (new Email())->priority($actualPriority);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected priority was not [{$expectedPriority}].");
+
+        $this->assertMailPriority($expectedPriority, $mail);
+    }
+
+    public function testMailNotPrioritySingleEmail()
+    {
+        $priorities = collect(range(1, 5))->shuffle();
+        $actualPriority = $priorities->pop();
+        $expectedPriority = $priorities->random();
+
+        $mail = (new Email())->priority($actualPriority);
+
+        $this->assertMailNotPriority($expectedPriority, $mail);
+    }
+
+    public function testMailNotPriorityThrowsProperExpectationFailedException()
+    {
+        $priority = mt_rand(1, 5);
+
+        $mail = (new Email())->priority($priority);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected priority was [{$priority}].");
+
+        $this->assertMailNotPriority($priority, $mail);
+    }
+
+    public function testMailPriorityHighest()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_HIGHEST);
+
+        $this->assertMailPriorityIsHighest($mail);
+    }
+
+    public function testMailPriorityHighestThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [highest].');
+
+        $this->assertMailPriorityIsHighest($mail);
+    }
+
+    public function testMailPriorityNotHighest()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotHighest($mail);
+    }
+
+    public function testMailPriorityNotHighestThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_HIGHEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [highest].');
+
+        $this->assertMailPriorityNotHighest($mail);
+    }
+
+    public function testMailPriorityHigh()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_HIGH);
+
+        $this->assertMailPriorityIsHigh($mail);
+    }
+
+    public function testMailPriorityHighThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [high].');
+
+        $this->assertMailPriorityIsHigh($mail);
+    }
+
+    public function testMailPriorityNotHigh()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotHigh($mail);
+    }
+
+    public function testMailPriorityNotHighThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_HIGH);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [high].');
+
+        $this->assertMailPriorityNotHigh($mail);
+    }
+
+    public function testMailPriorityNormal()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_NORMAL);
+
+        $this->assertMailPriorityIsNormal($mail);
+    }
+
+    public function testMailPriorityNormalThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [normal].');
+
+        $this->assertMailPriorityIsNormal($mail);
+    }
+
+    public function testMailPriorityNotNormal()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotNormal($mail);
+    }
+
+    public function testMailPriorityNotNormalThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_NORMAL);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [normal].');
+
+        $this->assertMailPriorityNotNormal($mail);
+    }
+
+    public function testMailPriorityLow()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->assertMailPriorityIsLow($mail);
+    }
+
+    public function testMailPriorityLowThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [low].');
+
+        $this->assertMailPriorityIsLow($mail);
+    }
+
+    public function testMailPriorityNotLow()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotLow($mail);
+    }
+
+    public function testMailPriorityNotLowThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [low].');
+
+        $this->assertMailPriorityNotLow($mail);
+    }
+
+    public function testMailPriorityLowest()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityIsLowest($mail);
+    }
+
+    public function testMailPriorityLowestThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was not [lowest].');
+
+        $this->assertMailPriorityIsLowest($mail);
+    }
+
+    public function testMailPriorityNotLowest()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->assertMailPriorityNotLowest($mail);
+    }
+
+    public function testMailPriorityNotLowestThrowsProperExpectationFailedException()
+    {
+        $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The expected priority was [lowest].');
+
+        $this->assertMailPriorityNotLowest($mail);
+    }
+}

--- a/tests/ReplyToAssertionsTest.php
+++ b/tests/ReplyToAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\ReplyToAssertions;
 
 class ReplyToAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use ReplyToAssertions;
-
     public function testMailRepliesToSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setReplyTo($email);
+        $mail = (new Email())->replyTo($email);
 
         $this->assertMailRepliesTo($email, $mail);
     }
@@ -25,7 +20,7 @@ class ReplyToAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setReplyTo($this->faker->unique->email);
+        $mail = (new Email())->replyTo($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail does not reply to the expected address [{$email}].");
@@ -40,7 +35,7 @@ class ReplyToAssertionsTest extends TestCase
             $this->faker->email,
         ];
 
-        $mail = (new Swift_Message())->setReplyTo($emails);
+        $mail = (new Email())->replyTo(...$emails);
 
         $this->assertMailRepliesTo($emails, $mail);
     }
@@ -49,7 +44,7 @@ class ReplyToAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setReplyTo($this->faker->unique()->email);
+        $mail = (new Email())->replyTo($this->faker->unique()->email);
 
         $this->assertMailNotRepliesTo($email, $mail);
     }
@@ -58,7 +53,7 @@ class ReplyToAssertionsTest extends TestCase
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setReplyTo($email);
+        $mail = (new Email())->replyTo($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail replied to the expected address [{$email}].");
@@ -73,10 +68,10 @@ class ReplyToAssertionsTest extends TestCase
             $this->faker->unique()->email,
         ];
 
-        $mail = (new Swift_Message())->setReplyTo([
+        $mail = (new Email())->replyTo(
             $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
+            $this->faker->unique()->email
+        );
 
         $this->assertMailNotRepliesTo($emails, $mail);
     }

--- a/tests/ReturnPathAssertionsTest.php
+++ b/tests/ReturnPathAssertionsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests;
+
+use Symfony\Component\Mime\Email;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class ReturnPathAssertionsTest extends TestCase
+{
+    public function testMailReturnPathSingleEmail()
+    {
+        $email = $this->faker->email;
+
+        $mail = (new Email())->returnPath($email);
+
+        $this->assertMailReturnPath($email, $mail);
+    }
+
+    public function testMailReturnPathThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = (new Email())->returnPath($this->faker->unique()->email);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected return path was not [{$email}].");
+
+        $this->assertMailReturnPath($email, $mail);
+    }
+
+    public function testMailNotReturnPathSingleEmail()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = (new Email())->returnPath($this->faker->unique()->email);
+
+        $this->assertMailNotReturnPath($email, $mail);
+    }
+
+    public function testMailNotReturnPathThrowsProperExpectationFailedException()
+    {
+        $email = $this->faker->email;
+
+        $mail = (new Email())->returnPath($email);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected return path was [{$email}].");
+
+        $this->assertMailNotReturnPath($email, $mail);
+    }
+}

--- a/tests/SenderAssertionsTest.php
+++ b/tests/SenderAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\SenderAssertions;
 
 class SenderAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use SenderAssertions;
-
     public function testMailSenderSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setSender($email);
+        $mail = (new Email())->sender($email);
 
         $this->assertMailSender($email, $mail);
     }
@@ -25,7 +20,7 @@ class SenderAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setSender($this->faker->unique->email);
+        $mail = (new Email())->sender($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail sender was not from the expected address [{$email}].");
@@ -33,23 +28,11 @@ class SenderAssertionsTest extends TestCase
         $this->assertMailSender($email, $mail);
     }
 
-    public function testMailSenderMultipleEmails()
-    {
-        $emails = [
-            $this->faker->email,
-            $this->faker->email,
-        ];
-
-        $mail = (new Swift_Message())->setSender($emails);
-
-        $this->assertMailSender($emails, $mail);
-    }
-
     public function testMailNotSenderSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setSender($this->faker->unique()->email);
+        $mail = (new Email())->sender($this->faker->unique()->email);
 
         $this->assertMailNotSender($email, $mail);
     }
@@ -58,26 +41,11 @@ class SenderAssertionsTest extends TestCase
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setSender($email);
+        $mail = (new Email())->sender($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail sender was from the expected address [{$email}].");
 
         $this->assertMailNotSender($email, $mail);
-    }
-
-    public function testMailNotSenderMultipleEmails()
-    {
-        $emails = [
-            $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ];
-
-        $mail = (new Swift_Message())->setSender([
-            $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
-
-        $this->assertMailNotSender($emails, $mail);
     }
 }

--- a/tests/SubjectAssertionsTest.php
+++ b/tests/SubjectAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\SubjectAssertions;
 
 class SubjectAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use SubjectAssertions;
-
     public function testMailSubject()
     {
         $subject = $this->faker->sentence;
 
-        $mail = (new Swift_Message())->setSubject($subject);
+        $mail = (new Email())->subject($subject);
 
         $this->assertMailSubject($subject, $mail);
     }
@@ -25,7 +20,7 @@ class SubjectAssertionsTest extends TestCase
     {
         $subject = $this->faker->unique()->sentence;
 
-        $mail = (new Swift_Message())->setSubject($this->faker->unique()->sentence);
+        $mail = (new Email())->subject($this->faker->unique()->sentence);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected subject was not [{$subject}].");
@@ -37,7 +32,7 @@ class SubjectAssertionsTest extends TestCase
     {
         $subject = $this->faker->unique()->sentence;
 
-        $mail = (new Swift_Message())->setSubject($this->faker->unique()->sentence);
+        $mail = (new Email())->subject($this->faker->unique()->sentence);
 
         $this->assertMailNotSubject($subject, $mail);
     }
@@ -46,7 +41,7 @@ class SubjectAssertionsTest extends TestCase
     {
         $subject = $this->faker->sentence;
 
-        $mail = (new Swift_Message())->setSubject($subject);
+        $mail = (new Email())->subject($subject);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("The expected subject was [{$subject}].");

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,12 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use KirschbaumDevelopment\MailIntercept\WithMailInterceptor;
 
 class TestCase extends OrchestraTestCase
 {
+    use WithFaker;
+    use WithMailInterceptor;
 }

--- a/tests/ToAssertionsTest.php
+++ b/tests/ToAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\ToAssertions;
 
 class ToAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use ToAssertions;
-
     public function testMailSentToSingleEmail()
     {
         $email = $this->faker->email;
 
-        $mail = (new Swift_Message())->setTo($email);
+        $mail = (new Email())->to($email);
 
         $this->assertMailSentTo($email, $mail);
     }
@@ -25,7 +20,7 @@ class ToAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setTo($this->faker->unique->email);
+        $mail = (new Email())->to($this->faker->unique()->email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was not sent to the expected address [{$email}].");
@@ -40,7 +35,7 @@ class ToAssertionsTest extends TestCase
             $this->faker->email,
         ];
 
-        $mail = (new Swift_Message())->setTo($emails);
+        $mail = (new Email())->to(...$emails);
 
         $this->assertMailSentTo($emails, $mail);
     }
@@ -49,7 +44,7 @@ class ToAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setTo($this->faker->unique()->email);
+        $mail = (new Email())->to($this->faker->unique()->email);
 
         $this->assertMailNotSentTo($email, $mail);
     }
@@ -58,7 +53,7 @@ class ToAssertionsTest extends TestCase
     {
         $email = $this->faker->unique()->email;
 
-        $mail = (new Swift_Message())->setTo($email);
+        $mail = (new Email())->to($email);
 
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage("Mail was sent to the expected address [{$email}].");
@@ -73,10 +68,10 @@ class ToAssertionsTest extends TestCase
             $this->faker->unique()->email,
         ];
 
-        $mail = (new Swift_Message())->setTo([
+        $mail = (new Email())->to(
             $this->faker->unique()->email,
-            $this->faker->unique()->email,
-        ]);
+            $this->faker->unique()->email
+        );
 
         $this->assertMailNotSentTo($emails, $mail);
     }

--- a/tests/UnstructuredHeaderAssertionsTest.php
+++ b/tests/UnstructuredHeaderAssertionsTest.php
@@ -2,21 +2,16 @@
 
 namespace Tests;
 
-use Swift_Message;
-use Illuminate\Foundation\Testing\WithFaker;
+use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
-use KirschbaumDevelopment\MailIntercept\Assertions\UnstructuredHeaderAssertions;
 
 class UnstructuredHeaderAssertionsTest extends TestCase
 {
-    use WithFaker;
-    use UnstructuredHeaderAssertions;
-
     public function testMailHasHeader()
     {
         $header = $this->faker->slug;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $this->faker->word);
 
         $this->assertMailHasHeader($header, $mail);
@@ -26,7 +21,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
     {
         $header = $this->faker->unique()->slug;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
 
         $this->expectException(ExpectationFailedException::class);
@@ -39,7 +34,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
     {
         $header = $this->faker->unique()->slug;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
 
         $this->assertMailMissingHeader($header, $mail);
@@ -49,7 +44,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
     {
         $header = $this->faker->slug;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $this->faker->word);
 
         $this->expectException(ExpectationFailedException::class);
@@ -63,7 +58,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $header = $this->faker->slug;
         $value = $this->faker->word;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $value);
 
         $this->assertMailHeaderIs($header, $value, $mail);
@@ -74,7 +69,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $header = $this->faker->slug;
         $value = $this->faker->unique()->word;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
 
         $this->expectException(ExpectationFailedException::class);
@@ -88,7 +83,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $header = $this->faker->slug;
         $value = $this->faker->unique()->word;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
 
         $this->assertMailHeaderIsNot($header, $value, $mail);
@@ -99,7 +94,7 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $header = $this->faker->slug;
         $value = $this->faker->word;
 
-        $mail = (new Swift_Message());
+        $mail = (new Email());
         $mail->getHeaders()->addTextHeader($header, $value);
 
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
- Upgraded for Laravel 9
- Added new assertions methods:
  - `assertMailHasPlainContent`
  - `assertMailDoesNotHavePlainContent`
  - `assertMailHasHtmlContent`
  - `assertMailDoesNotHaveHtmlContent`
  - `assertMailIsAlternative`
  - `assertMailIsNotAlternative`
  - `assertMailIsMixed`
  - `assertMailIsNotMixed`
  - `assertMailPriority`
  - `assertMailNotPriority`
  - `assertMailPriorityIsHighest`
  - `assertMailPriorityNotHighest`
  - `assertMailPriorityIsHigh`
  - `assertMailPriorityNotHigh`
  - `assertMailPriorityIsNormal`
  - `assertMailPriorityNotNormal`
  - `assertMailPriorityIsLow`
  - `assertMailPriorityNotLow`
  - `assertMailPriorityIsLowest`
  - `assertMailPriorityNotLowest`
  - `assertMailReturnPath`
  - `assertMailNotReturnPath`