### PR TITLE
Add AssertableMessage to method signatures

### DIFF
--- a/src/Assertions/ContentAssertions.php
+++ b/src/Assertions/ContentAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ContentAssertions
 {
@@ -12,7 +13,7 @@ trait ContentAssertions
      * @param string $needle
      * @param Email $mail
      */
-    public function assertMailBodyContainsString(string $needle, Email $mail)
+    public function assertMailBodyContainsString(string $needle, AssertableMessage|Email $mail)
     {
         $method = method_exists($this, 'assertStringContainsString')
             ? 'assertStringContainsString'
@@ -31,7 +32,7 @@ trait ContentAssertions
      * @param string $needle
      * @param Email $mail
      */
-    public function assertMailBodyNotContainsString(string $needle, Email $mail)
+    public function assertMailBodyNotContainsString(string $needle, AssertableMessage|Email $mail)
     {
         $method = method_exists($this, 'assertStringNotContainsString')
             ? 'assertStringNotContainsString'


### PR DESCRIPTION
The `assertMailBodyContainsString` and `assertMailBodyNotContainsString` assertions don't currently work with the documented use, because `interceptedMail()` returns an array of AssertableMessage objects. This just adds the AssertableMessage type to the method signatures.