### PR TITLE
Assertable message updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `mail-intercept` will be documented in this file
 
+## 0.3.1 - 2022-05-20
+
+- Better type-hinting for `AssertableMessage` class in assertions. Thank you [@amsoel](https://github.com/amsoell).
+
 ## 0.3.0 - 2022-03-08
 
 - Upgraded for Laravel 9

--- a/src/AssertableMessage.php
+++ b/src/AssertableMessage.php
@@ -80,8 +80,8 @@ class AssertableMessage extends Assert
     /**
      * Dynamically pass missing methods to the Symfony instance.
      *
-     * @param  string  $method
-     * @param  array  $parameters
+     * @param string $method
+     * @param array $parameters
      *
      * @return mixed
      */

--- a/src/Assertions/BccAssertions.php
+++ b/src/Assertions/BccAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Illuminate\Support\Arr;
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait BccAssertions
 {
@@ -11,9 +12,9 @@ trait BccAssertions
      * Assert mail was BCC'd to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailBcc(array|string $expected, Email $mail)
+    public function assertMailBcc(array|string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getBcc', $mail);
@@ -31,9 +32,9 @@ trait BccAssertions
      * Assert mail was not BCC'd to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotBcc(array|string $expected, Email $mail)
+    public function assertMailNotBcc(array|string $expected, AssertableMessage | Email $mail): void
     {
         $addresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getBcc', $mail);

--- a/src/Assertions/CcAssertions.php
+++ b/src/Assertions/CcAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Illuminate\Support\Arr;
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait CcAssertions
 {
@@ -11,9 +12,9 @@ trait CcAssertions
      * Assert mail was CC'd to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailCc(array|string $expected, Email $mail)
+    public function assertMailCc(array|string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getCc', $mail);
@@ -31,9 +32,9 @@ trait CcAssertions
      * Assert mail was not CC'd to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotCc(array|string $expected, Email $mail)
+    public function assertMailNotCc(array|string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getCc', $mail);

--- a/src/Assertions/ContentAssertions.php
+++ b/src/Assertions/ContentAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ContentAssertions
 {
@@ -10,9 +11,9 @@ trait ContentAssertions
      * Assert mail body contains string.
      *
      * @param string $needle
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailBodyContainsString(string $needle, Email $mail)
+    public function assertMailBodyContainsString(string $needle, AssertableMessage | Email $mail): void
     {
         $method = method_exists($this, 'assertStringContainsString')
             ? 'assertStringContainsString'
@@ -29,9 +30,9 @@ trait ContentAssertions
      * Assert mail body does not contain string.
      *
      * @param string $needle
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailBodyNotContainsString(string $needle, Email $mail)
+    public function assertMailBodyNotContainsString(string $needle, AssertableMessage | Email $mail): void
     {
         $method = method_exists($this, 'assertStringNotContainsString')
             ? 'assertStringNotContainsString'

--- a/src/Assertions/ContentTypeAssertions.php
+++ b/src/Assertions/ContentTypeAssertions.php
@@ -4,15 +4,16 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\AbstractMultipartPart;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ContentTypeAssertions
 {
     /**
      * Assert mail content type is text/plain.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsPlain(Email $mail)
+    public function assertMailIsPlain(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             'plain',
@@ -24,9 +25,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not text/plain.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsNotPlain(Email $mail)
+    public function assertMailIsNotPlain(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             'plain',
@@ -38,9 +39,9 @@ trait ContentTypeAssertions
     /**
      * Assert multipart email has text/plain content type.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailHasPlainContent(Email $mail)
+    public function assertMailHasPlainContent(AssertableMessage | Email $mail): void
     {
         if ($mail->getBody() instanceof AbstractMultipartPart) {
             $hasPlainContent = collect($mail->getBody()->getParts())
@@ -56,9 +57,9 @@ trait ContentTypeAssertions
     /**
      * Assert multipart email does not have text/plain content type.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailDoesNotHavePlainContent(Email $mail)
+    public function assertMailDoesNotHavePlainContent(AssertableMessage | Email $mail): void
     {
         if ($mail->getBody() instanceof AbstractMultipartPart) {
             $hasPlainContent = collect($mail->getBody()->getParts())
@@ -74,9 +75,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is text/html.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsHtml(Email $mail)
+    public function assertMailIsHtml(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             'html',
@@ -88,9 +89,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not text/html.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsNotHtml(Email $mail)
+    public function assertMailIsNotHtml(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             'html',
@@ -102,9 +103,9 @@ trait ContentTypeAssertions
     /**
      * Assert multipart email has text/html content type.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailHasHtmlContent(Email $mail)
+    public function assertMailHasHtmlContent(AssertableMessage | Email $mail): void
     {
         if ($mail->getBody() instanceof AbstractMultipartPart) {
             $hasHtmlContent = collect($mail->getBody()->getParts())
@@ -120,9 +121,9 @@ trait ContentTypeAssertions
     /**
      * Assert multipart email does not have text/html content type.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailDoesNotHaveHtmlContent(Email $mail)
+    public function assertMailDoesNotHaveHtmlContent(AssertableMessage | Email $mail): void
     {
         if ($mail->getBody() instanceof AbstractMultipartPart) {
             $hasHtmlContent = collect($mail->getBody()->getParts())
@@ -138,9 +139,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is multipart/alternative.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsAlternative(Email $mail)
+    public function assertMailIsAlternative(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             'alternative',
@@ -152,9 +153,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not multipart/alternative.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsNotAlternative(Email $mail)
+    public function assertMailIsNotAlternative(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             'alternative',
@@ -166,9 +167,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is multipart/mixed.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsMixed(Email $mail)
+    public function assertMailIsMixed(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             'mixed',
@@ -180,9 +181,9 @@ trait ContentTypeAssertions
     /**
      * Assert mail content type is not multipart/mixed.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailIsNotMixed(Email $mail)
+    public function assertMailIsNotMixed(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             'mixed',

--- a/src/Assertions/FromAssertions.php
+++ b/src/Assertions/FromAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Illuminate\Support\Arr;
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait FromAssertions
 {
@@ -11,9 +12,9 @@ trait FromAssertions
      * Assert mail was sent from address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailSentFrom(array|string $expected, Email $mail)
+    public function assertMailSentFrom(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getFrom', $mail);
@@ -31,9 +32,9 @@ trait FromAssertions
      * Assert mail was not sent from address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotSentFrom(array|string $expected, Email $mail)
+    public function assertMailNotSentFrom(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getFrom', $mail);

--- a/src/Assertions/PriorityAssertions.php
+++ b/src/Assertions/PriorityAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait PriorityAssertions
 {
@@ -10,9 +11,9 @@ trait PriorityAssertions
      * Assert mail has priority.
      *
      * @param int $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriority(int $expected, Email $mail)
+    public function assertMailPriority(int $expected, AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             $expected,
@@ -25,9 +26,9 @@ trait PriorityAssertions
      * Assert mail does not have priority.
      *
      * @param int $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotPriority(int $expected, Email $mail)
+    public function assertMailNotPriority(int $expected, AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             $expected,
@@ -39,9 +40,9 @@ trait PriorityAssertions
     /**
      * Assert mail has the highest priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityIsHighest(Email $mail)
+    public function assertMailPriorityIsHighest(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             Email::PRIORITY_HIGHEST,
@@ -53,9 +54,9 @@ trait PriorityAssertions
     /**
      * Assert mail does not have the highest priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityNotHighest(Email $mail)
+    public function assertMailPriorityNotHighest(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             Email::PRIORITY_HIGHEST,
@@ -67,9 +68,9 @@ trait PriorityAssertions
     /**
      * Assert mail has high priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityIsHigh(Email $mail)
+    public function assertMailPriorityIsHigh(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             Email::PRIORITY_HIGH,
@@ -81,9 +82,9 @@ trait PriorityAssertions
     /**
      * Assert mail does not have high priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityNotHigh(Email $mail)
+    public function assertMailPriorityNotHigh(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             Email::PRIORITY_HIGH,
@@ -95,9 +96,9 @@ trait PriorityAssertions
     /**
      * Assert mail has normal priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityIsNormal(Email $mail)
+    public function assertMailPriorityIsNormal(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             Email::PRIORITY_NORMAL,
@@ -109,9 +110,9 @@ trait PriorityAssertions
     /**
      * Assert mail does not have normal priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityNotNormal(Email $mail)
+    public function assertMailPriorityNotNormal(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             Email::PRIORITY_NORMAL,
@@ -123,9 +124,9 @@ trait PriorityAssertions
     /**
      * Assert mail has low priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityIsLow(Email $mail)
+    public function assertMailPriorityIsLow(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             Email::PRIORITY_LOW,
@@ -137,9 +138,9 @@ trait PriorityAssertions
     /**
      * Assert mail does not have low priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityNotLow(Email $mail)
+    public function assertMailPriorityNotLow(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             Email::PRIORITY_LOW,
@@ -151,9 +152,9 @@ trait PriorityAssertions
     /**
      * Assert mail has the lowest priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityIsLowest(Email $mail)
+    public function assertMailPriorityIsLowest(AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             Email::PRIORITY_LOWEST,
@@ -165,9 +166,9 @@ trait PriorityAssertions
     /**
      * Assert mail does not have the lowest priority.
      *
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailPriorityNotLowest(Email $mail)
+    public function assertMailPriorityNotLowest(AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             Email::PRIORITY_LOWEST,

--- a/src/Assertions/ReplyToAssertions.php
+++ b/src/Assertions/ReplyToAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Illuminate\Support\Arr;
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ReplyToAssertions
 {
@@ -11,9 +12,9 @@ trait ReplyToAssertions
      * Assert mail replies to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailRepliesTo(array|string $expected, Email $mail)
+    public function assertMailRepliesTo(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getReplyTo', $mail);
@@ -31,9 +32,9 @@ trait ReplyToAssertions
      * Assert mail does not reply to address.
      *
      * @param array|string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotRepliesTo(array|string $expected, Email $mail)
+    public function assertMailNotRepliesTo(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getReplyTo', $mail);

--- a/src/Assertions/ReturnPathAssertions.php
+++ b/src/Assertions/ReturnPathAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait ReturnPathAssertions
 {
@@ -10,9 +11,9 @@ trait ReturnPathAssertions
      * Assert mail has return path.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailReturnPath(string $expected, Email $mail)
+    public function assertMailReturnPath(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             $expected,
@@ -25,9 +26,9 @@ trait ReturnPathAssertions
      * Assert mail does not have return path.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotReturnPath(string $expected, Email $mail)
+    public function assertMailNotReturnPath(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             $expected,

--- a/src/Assertions/SenderAssertions.php
+++ b/src/Assertions/SenderAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait SenderAssertions
 {
@@ -10,9 +11,9 @@ trait SenderAssertions
      * Assert mail sender was address.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailSender(string $expected, Email $mail)
+    public function assertMailSender(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             $expected,
@@ -25,9 +26,9 @@ trait SenderAssertions
      * Assert mail was not sender address.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotSender(string $expected, Email $mail)
+    public function assertMailNotSender(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             $expected,

--- a/src/Assertions/SubjectAssertions.php
+++ b/src/Assertions/SubjectAssertions.php
@@ -3,6 +3,7 @@
 namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait SubjectAssertions
 {
@@ -10,9 +11,9 @@ trait SubjectAssertions
      * Assert mail has subject.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailSubject(string $expected, Email $mail)
+    public function assertMailSubject(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             $expected,
@@ -25,9 +26,9 @@ trait SubjectAssertions
      * Assert mail does not have subject.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotSubject(string $expected, Email $mail)
+    public function assertMailNotSubject(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             $expected,

--- a/src/Assertions/ToAssertions.php
+++ b/src/Assertions/ToAssertions.php
@@ -14,7 +14,7 @@ trait ToAssertions
      * @param array|string $expected
      * @param AssertableMessage|Email $mail
      */
-    public function assertMailSentTo(array|string $expected, AssertableMessage|Email $mail)
+    public function assertMailSentTo(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getTo', $mail);
@@ -34,7 +34,7 @@ trait ToAssertions
      * @param array|string $expected
      * @param AssertableMessage|Email $mail
      */
-    public function assertMailNotSentTo(array|string $expected, AssertableMessage|Email $mail)
+    public function assertMailNotSentTo(array | string $expected, AssertableMessage | Email $mail): void
     {
         $expectedAddresses = Arr::wrap($expected);
         $actualAddresses = $this->gatherEmailData('getTo', $mail);

--- a/src/Assertions/UnstructuredHeaderAssertions.php
+++ b/src/Assertions/UnstructuredHeaderAssertions.php
@@ -4,6 +4,7 @@ namespace KirschbaumDevelopment\MailIntercept\Assertions;
 
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 trait UnstructuredHeaderAssertions
 {
@@ -11,9 +12,9 @@ trait UnstructuredHeaderAssertions
      * Assert unstructured header exists.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailHasHeader(string $expected, Email $mail)
+    public function assertMailHasHeader(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertInstanceOf(
             UnstructuredHeader::class,
@@ -26,9 +27,9 @@ trait UnstructuredHeaderAssertions
      * Assert unstructured header exists.
      *
      * @param string $expected
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailMissingHeader(string $expected, Email $mail)
+    public function assertMailMissingHeader(string $expected, AssertableMessage | Email $mail): void
     {
         $this->assertNull(
             $mail->getHeaders()->get($expected),
@@ -41,9 +42,9 @@ trait UnstructuredHeaderAssertions
      *
      * @param string $expected
      * @param string $expectedValue
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailHeaderIs(string $expected, string $expectedValue, Email $mail)
+    public function assertMailHeaderIs(string $expected, string $expectedValue, AssertableMessage | Email $mail): void
     {
         $this->assertEquals(
             $expectedValue,
@@ -57,9 +58,9 @@ trait UnstructuredHeaderAssertions
      *
      * @param string $expected
      * @param string $expectedValue
-     * @param Email $mail
+     * @param AssertableMessage|Email $mail
      */
-    public function assertMailHeaderIsNot(string $expected, string $expectedValue, Email $mail)
+    public function assertMailHeaderIsNot(string $expected, string $expectedValue, AssertableMessage | Email $mail): void
     {
         $this->assertNotEquals(
             $expectedValue,

--- a/src/WithMailInterceptor.php
+++ b/src/WithMailInterceptor.php
@@ -37,7 +37,7 @@ trait WithMailInterceptor
     /**
      * Intercept Symfony Mailer so we can dissect the mail.
      */
-    public function interceptMail()
+    public function interceptMail(): void
     {
         Config::set('mail.driver', 'array');
     }
@@ -64,7 +64,7 @@ trait WithMailInterceptor
      *
      * @return array
      */
-    protected function gatherEmailData(string $method, AssertableMessage|Email $mail): array
+    protected function gatherEmailData(string $method, AssertableMessage | Email $mail): array
     {
         return collect($mail->$method())
             ->map(fn ($address) => $address->getAddress())

--- a/tests/BccAssertionsTest.php
+++ b/tests/BccAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class BccAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailBcc
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailBccSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->bcc($email);
+
+        $this->assertMailBcc($email, $mail);
+    }
+
+    public function testMailBccSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($email)
+        );
 
         $this->assertMailBcc($email, $mail);
     }
@@ -40,11 +58,28 @@ class BccAssertionsTest extends TestCase
         $this->assertMailBcc($emails, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotBcc
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSentToSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->bcc($this->faker->unique()->email);
+
+        $this->assertMailNotBcc($email, $mail);
+    }
+
+    public function testMailNotSentToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->bcc($this->faker->unique()->email)
+        );
 
         $this->assertMailNotBcc($email, $mail);
     }

--- a/tests/CcAssertionsTest.php
+++ b/tests/CcAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class CcAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailCc
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailCcSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->cc($email);
+
+        $this->assertMailCc($email, $mail);
+    }
+
+    public function testMailCcSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($email)
+        );
 
         $this->assertMailCc($email, $mail);
     }
@@ -40,11 +58,28 @@ class CcAssertionsTest extends TestCase
         $this->assertMailCc($emails, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotCc
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSentToSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->cc($this->faker->unique()->email);
+
+        $this->assertMailNotCc($email, $mail);
+    }
+
+    public function testMailNotSentToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->cc($this->faker->unique()->email)
+        );
 
         $this->assertMailNotCc($email, $mail);
     }

--- a/tests/ContentAssertionsTest.php
+++ b/tests/ContentAssertionsTest.php
@@ -5,9 +5,16 @@ namespace Tests;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\TextPart;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class ContentAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailBodyContainsString
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailBodyContentsAsText()
     {
         $content = $this->faker->sentence;
@@ -16,6 +23,20 @@ class ContentAssertionsTest extends TestCase
             ->to($this->faker->email)
             ->from($this->faker->email)
             ->text($content);
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsTextViaAssertableMessage()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($content)
+        );
 
         $this->assertMailBodyContainsString($content, $mail);
     }
@@ -33,33 +54,6 @@ class ContentAssertionsTest extends TestCase
         $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
 
         $this->assertMailBodyContainsString($content, $mail);
-    }
-
-    public function testMailBodyAsTextDoesNotHaveContents()
-    {
-        $content = $this->faker->unique()->sentence;
-
-        $mail = (new Email())
-            ->to($this->faker->email)
-            ->from($this->faker->email)
-            ->text($this->faker->unique()->sentence);
-
-        $this->assertMailBodyNotContainsString($content, $mail);
-    }
-
-    public function testMailBodyAsTextDoesNotHaveContentsThrowsProperExpectationFailedException()
-    {
-        $content = $this->faker->sentence;
-
-        $mail = (new Email())
-            ->to($this->faker->email)
-            ->from($this->faker->email)
-            ->text($content);
-
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
-
-        $this->assertMailBodyNotContainsString($content, $mail);
     }
 
     public function testMailBodyContentsAsHtml()
@@ -89,6 +83,76 @@ class ContentAssertionsTest extends TestCase
         $this->assertMailBodyContainsString($content, $mail);
     }
 
+    public function testMailBodyContentsAsAbstractPart()
+    {
+        $content = $this->faker->sentence;
+        $textPart = new TextPart($content);
+
+        $mail = (new Email())->setBody($textPart);
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    public function testMailBodyContentsAsAbstractPartThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->unique()->sentence;
+        $textPart = new TextPart($this->faker->unique()->sentence);
+
+        $mail = (new Email())->setBody($textPart);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
+
+        $this->assertMailBodyContainsString($content, $mail);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailBodyNotContainsString
+    |--------------------------------------------------------------------------
+    */
+
+    public function testMailBodyAsTextDoesNotHaveContents()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($this->faker->unique()->sentence);
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsTextDoesNotHaveContentsViaAssertableMessage()
+    {
+        $content = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->unique()->sentence)
+        );
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
+    public function testMailBodyAsTextDoesNotHaveContentsThrowsProperExpectationFailedException()
+    {
+        $content = $this->faker->sentence;
+
+        $mail = (new Email())
+            ->to($this->faker->email)
+            ->from($this->faker->email)
+            ->text($content);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
+
+        $this->assertMailBodyNotContainsString($content, $mail);
+    }
+
     public function testMailBodyAsHtmlDoesNotHaveContents()
     {
         $content = $this->faker->unique()->sentence;
@@ -114,29 +178,6 @@ class ContentAssertionsTest extends TestCase
         $this->expectExceptionMessage("The expected [{$content}] string was found in the body.");
 
         $this->assertMailBodyNotContainsString($content, $mail);
-    }
-
-    public function testMailBodyContentsAsAbstractPart()
-    {
-        $content = $this->faker->sentence;
-        $textPart = new TextPart($content);
-
-        $mail = (new Email())->setBody($textPart);
-
-        $this->assertMailBodyContainsString($content, $mail);
-    }
-
-    public function testMailBodyContentsAsAbstractPartThrowsProperExpectationFailedException()
-    {
-        $content = $this->faker->unique()->sentence;
-        $textPart = new TextPart($this->faker->unique()->sentence);
-
-        $mail = (new Email())->setBody($textPart);
-
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage("The expected [{$content}] string was not found in the body.");
-
-        $this->assertMailBodyContainsString($content, $mail);
     }
 
     public function testMailBodyAsAbstractPartDoesNotHaveContents()

--- a/tests/ContentTypeAssertionsTest.php
+++ b/tests/ContentTypeAssertionsTest.php
@@ -5,15 +5,34 @@ namespace Tests;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\TextPart;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class ContentTypeAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsPlain
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypePlain()
     {
         $mail = (new Email())
             ->to($this->faker->email)
             ->from($this->faker->email)
             ->text($this->faker->sentence);
+
+        $this->assertMailIsPlain($mail);
+    }
+
+    public function testMailContentTypePlainViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+        );
 
         $this->assertMailIsPlain($mail);
     }
@@ -29,10 +48,26 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsPlain($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsNotPlain
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeNotPlain()
     {
         $part = new TextPart('body', subtype: 'not-plain');
         $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotPlain($mail);
+    }
+
+    public function testMailContentTypeNotPlainViaAssertableMessage()
+    {
+        $part = new TextPart('body', subtype: 'not-plain');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
 
         $this->assertMailIsNotPlain($mail);
     }
@@ -50,6 +85,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsNotPlain($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailHasPlainContent
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailHasPlainContent()
     {
         $mail = (new Email())
@@ -57,6 +98,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->text($this->faker->sentence)
             ->html($this->faker->sentence);
+
+        $this->assertMailHasPlainContent($mail);
+    }
+
+    public function testMailHasPlainContentViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
 
         $this->assertMailHasPlainContent($mail);
     }
@@ -75,6 +129,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailHasPlainContent($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailDoesNotHavePlainContent
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailDoesNotHavePlainContent()
     {
         $mail = (new Email())
@@ -82,6 +142,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->attach('attachment')
             ->html($this->faker->sentence);
+
+        $this->assertMailDoesNotHavePlainContent($mail);
+    }
+
+    public function testMailDoesNotHavePlainContentViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->html($this->faker->sentence)
+        );
 
         $this->assertMailDoesNotHavePlainContent($mail);
     }
@@ -100,12 +173,30 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailDoesNotHavePlainContent($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsHtml
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeHtml()
     {
         $mail = (new Email())
             ->to($this->faker->email)
             ->from($this->faker->email)
             ->html($this->faker->sentence);
+
+        $this->assertMailIsHtml($mail);
+    }
+
+    public function testMailContentTypeHtmlViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->html($this->faker->sentence)
+        );
 
         $this->assertMailIsHtml($mail);
     }
@@ -121,10 +212,26 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsHtml($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsNotHtml
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeNotHtml()
     {
         $part = new TextPart('body', subtype: 'not-html');
         $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotHtml($mail);
+    }
+
+    public function testMailContentTypeNotHtmlViaAssertableMessage()
+    {
+        $part = new TextPart('body', subtype: 'not-html');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
 
         $this->assertMailIsNotHtml($mail);
     }
@@ -142,6 +249,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsNotHtml($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailHasHtmlContent
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailHasHtmlContent()
     {
         $mail = (new Email())
@@ -149,6 +262,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->text($this->faker->sentence)
             ->html($this->faker->sentence);
+
+        $this->assertMailHasHtmlContent($mail);
+    }
+
+    public function testMailHasHtmlContentViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
 
         $this->assertMailHasHtmlContent($mail);
     }
@@ -167,6 +293,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailHasHtmlContent($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailDoesNotHaveHtmlContent
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailDoesNotHaveHtmlContent()
     {
         $mail = (new Email())
@@ -174,6 +306,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->attach('attachment')
             ->text($this->faker->sentence);
+
+        $this->assertMailDoesNotHaveHtmlContent($mail);
+    }
+
+    public function testMailDoesNotHaveHtmlContentViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
 
         $this->assertMailDoesNotHaveHtmlContent($mail);
     }
@@ -192,6 +337,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailDoesNotHaveHtmlContent($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsAlternative
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeAlternative()
     {
         $mail = (new Email())
@@ -199,6 +350,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->text($this->faker->sentence)
             ->html($this->faker->sentence);
+
+        $this->assertMailIsAlternative($mail);
+    }
+
+    public function testMailContentTypeAlternativeViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->text($this->faker->sentence)
+                ->html($this->faker->sentence)
+        );
 
         $this->assertMailIsAlternative($mail);
     }
@@ -214,10 +378,26 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsAlternative($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsNotAlternative
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeNotAlternative()
     {
         $part = new TextPart('body', subtype: 'not-alternative');
         $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotAlternative($mail);
+    }
+
+    public function testMailContentTypeNotAlternativeViaAssertableMessage()
+    {
+        $part = new TextPart('body', subtype: 'not-alternative');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
 
         $this->assertMailIsNotAlternative($mail);
     }
@@ -236,6 +416,12 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsNotAlternative($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsMixed
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeMixed()
     {
         $mail = (new Email())
@@ -243,6 +429,19 @@ class ContentTypeAssertionsTest extends TestCase
             ->from($this->faker->email)
             ->attach('attachment')
             ->text($this->faker->sentence);
+
+        $this->assertMailIsMixed($mail);
+    }
+
+    public function testMailContentTypeMixedViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())
+                ->to($this->faker->email)
+                ->from($this->faker->email)
+                ->attach('attachment')
+                ->text($this->faker->sentence)
+        );
 
         $this->assertMailIsMixed($mail);
     }
@@ -258,10 +457,26 @@ class ContentTypeAssertionsTest extends TestCase
         $this->assertMailIsMixed($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailIsNotMixed
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailContentTypeNotMixed()
     {
         $part = new TextPart('body', subtype: 'not-mixed');
         $mail = (new Email())->setBody($part);
+
+        $this->assertMailIsNotMixed($mail);
+    }
+
+    public function testMailContentTypeNotMixedViaAssertableMessage()
+    {
+        $part = new TextPart('body', subtype: 'not-mixed');
+        $mail = new AssertableMessage(
+            (new Email())->setBody($part)
+        );
 
         $this->assertMailIsNotMixed($mail);
     }

--- a/tests/FromAssertionsTest.php
+++ b/tests/FromAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class FromAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailSentFrom
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailSentFromSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->from($email);
+
+        $this->assertMailSentFrom($email, $mail);
+    }
+
+    public function testMailSentFromSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($email)
+        );
 
         $this->assertMailSentFrom($email, $mail);
     }
@@ -40,11 +58,28 @@ class FromAssertionsTest extends TestCase
         $this->assertMailSentFrom($emails, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotSentFrom
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSentFromSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->from($this->faker->unique()->email);
+
+        $this->assertMailNotSentFrom($email, $mail);
+    }
+
+    public function testMailNotSentFromSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->from($this->faker->unique()->email)
+        );
 
         $this->assertMailNotSentFrom($email, $mail);
     }

--- a/tests/PriorityAssertionsTest.php
+++ b/tests/PriorityAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class PriorityAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriority
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPrioritySingleEmail()
     {
         $priority = mt_rand(1, 5);
 
         $mail = (new Email())->priority($priority);
+
+        $this->assertMailPriority($priority, $mail);
+    }
+
+    public function testMailPrioritySingleEmailViaAssertableMessage()
+    {
+        $priority = mt_rand(1, 5);
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($priority)
+        );
 
         $this->assertMailPriority($priority, $mail);
     }
@@ -30,6 +48,12 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriority($expectedPriority, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotPriority
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotPrioritySingleEmail()
     {
         $priorities = collect(range(1, 5))->shuffle();
@@ -37,6 +61,19 @@ class PriorityAssertionsTest extends TestCase
         $expectedPriority = $priorities->random();
 
         $mail = (new Email())->priority($actualPriority);
+
+        $this->assertMailNotPriority($expectedPriority, $mail);
+    }
+
+    public function testMailNotPrioritySingleEmailViaAssertableMessage()
+    {
+        $priorities = collect(range(1, 5))->shuffle();
+        $actualPriority = $priorities->pop();
+        $expectedPriority = $priorities->random();
+
+        $mail = new AssertableMessage(
+            (new Email())->priority($actualPriority)
+        );
 
         $this->assertMailNotPriority($expectedPriority, $mail);
     }
@@ -53,9 +90,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailNotPriority($priority, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityIsHighest
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityHighest()
     {
         $mail = (new Email())->priority(Email::PRIORITY_HIGHEST);
+
+        $this->assertMailPriorityIsHighest($mail);
+    }
+
+    public function testMailPriorityHighestViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGHEST)
+        );
 
         $this->assertMailPriorityIsHighest($mail);
     }
@@ -70,9 +122,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityIsHighest($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityNotHighest
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNotHighest()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotHighest($mail);
+    }
+
+    public function testMailPriorityNotHighestViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
 
         $this->assertMailPriorityNotHighest($mail);
     }
@@ -87,9 +154,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityNotHighest($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityIsHigh
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityHigh()
     {
         $mail = (new Email())->priority(Email::PRIORITY_HIGH);
+
+        $this->assertMailPriorityIsHigh($mail);
+    }
+
+    public function testMailPriorityHighViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_HIGH)
+        );
 
         $this->assertMailPriorityIsHigh($mail);
     }
@@ -104,9 +186,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityIsHigh($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityNotHigh
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNotHigh()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotHigh($mail);
+    }
+
+    public function testMailPriorityNotHighViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
 
         $this->assertMailPriorityNotHigh($mail);
     }
@@ -121,9 +218,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityNotHigh($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityIsNormal
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNormal()
     {
         $mail = (new Email())->priority(Email::PRIORITY_NORMAL);
+
+        $this->assertMailPriorityIsNormal($mail);
+    }
+
+    public function testMailPriorityNormalViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_NORMAL)
+        );
 
         $this->assertMailPriorityIsNormal($mail);
     }
@@ -138,9 +250,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityIsNormal($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityNotNormal
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNotNormal()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotNormal($mail);
+    }
+
+    public function testMailPriorityNotNormalViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
 
         $this->assertMailPriorityNotNormal($mail);
     }
@@ -155,9 +282,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityNotNormal($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityIsLow
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityLow()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->assertMailPriorityIsLow($mail);
+    }
+
+    public function testMailPriorityLowViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
 
         $this->assertMailPriorityIsLow($mail);
     }
@@ -172,9 +314,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityIsLow($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityNotLow
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNotLow()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityNotLow($mail);
+    }
+
+    public function testMailPriorityNotLowViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
 
         $this->assertMailPriorityNotLow($mail);
     }
@@ -189,9 +346,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityNotLow($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityIsLowest
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityLowest()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOWEST);
+
+        $this->assertMailPriorityIsLowest($mail);
+    }
+
+    public function testMailPriorityLowestViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOWEST)
+        );
 
         $this->assertMailPriorityIsLowest($mail);
     }
@@ -206,9 +378,24 @@ class PriorityAssertionsTest extends TestCase
         $this->assertMailPriorityIsLowest($mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailPriorityNotLowest
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailPriorityNotLowest()
     {
         $mail = (new Email())->priority(Email::PRIORITY_LOW);
+
+        $this->assertMailPriorityNotLowest($mail);
+    }
+
+    public function testMailPriorityNotLowestViaAssertableMessage()
+    {
+        $mail = new AssertableMessage(
+            (new Email())->priority(Email::PRIORITY_LOW)
+        );
 
         $this->assertMailPriorityNotLowest($mail);
     }

--- a/tests/ReplyToAssertionsTest.php
+++ b/tests/ReplyToAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class ReplyToAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailRepliesTo
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailRepliesToSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->replyTo($email);
+
+        $this->assertMailRepliesTo($email, $mail);
+    }
+
+    public function testMailRepliesToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($email)
+        );
 
         $this->assertMailRepliesTo($email, $mail);
     }
@@ -40,11 +58,28 @@ class ReplyToAssertionsTest extends TestCase
         $this->assertMailRepliesTo($emails, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotRepliesTo
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotRepliesToSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->replyTo($this->faker->unique()->email);
+
+        $this->assertMailNotRepliesTo($email, $mail);
+    }
+
+    public function testMailNotRepliesToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->replyTo($this->faker->unique()->email)
+        );
 
         $this->assertMailNotRepliesTo($email, $mail);
     }

--- a/tests/ReturnPathAssertionsTest.php
+++ b/tests/ReturnPathAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class ReturnPathAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailReturnPath
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailReturnPathSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->returnPath($email);
+
+        $this->assertMailReturnPath($email, $mail);
+    }
+
+    public function testMailReturnPathSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($email)
+        );
 
         $this->assertMailReturnPath($email, $mail);
     }
@@ -28,11 +46,28 @@ class ReturnPathAssertionsTest extends TestCase
         $this->assertMailReturnPath($email, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotReturnPath
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotReturnPathSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->returnPath($this->faker->unique()->email);
+
+        $this->assertMailNotReturnPath($email, $mail);
+    }
+
+    public function testMailNotReturnPathSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->returnPath($this->faker->unique()->email)
+        );
 
         $this->assertMailNotReturnPath($email, $mail);
     }

--- a/tests/SenderAssertionsTest.php
+++ b/tests/SenderAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class SenderAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailSender
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailSenderSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->sender($email);
+
+        $this->assertMailSender($email, $mail);
+    }
+
+    public function testMailSenderSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($email)
+        );
 
         $this->assertMailSender($email, $mail);
     }
@@ -28,11 +46,28 @@ class SenderAssertionsTest extends TestCase
         $this->assertMailSender($email, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotSender
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSenderSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->sender($this->faker->unique()->email);
+
+        $this->assertMailNotSender($email, $mail);
+    }
+
+    public function testMailNotSenderSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->sender($this->faker->unique()->email)
+        );
 
         $this->assertMailNotSender($email, $mail);
     }

--- a/tests/SubjectAssertionsTest.php
+++ b/tests/SubjectAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class SubjectAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailSubject
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailSubject()
     {
         $subject = $this->faker->sentence;
 
         $mail = (new Email())->subject($subject);
+
+        $this->assertMailSubject($subject, $mail);
+    }
+
+    public function testMailSubjectViaAssertableMessage()
+    {
+        $subject = $this->faker->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($subject)
+        );
 
         $this->assertMailSubject($subject, $mail);
     }
@@ -28,11 +46,28 @@ class SubjectAssertionsTest extends TestCase
         $this->assertMailSubject($subject, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotSubject
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSubject()
     {
         $subject = $this->faker->unique()->sentence;
 
         $mail = (new Email())->subject($this->faker->unique()->sentence);
+
+        $this->assertMailNotSubject($subject, $mail);
+    }
+
+    public function testMailNotSubjectViaAssertableMessage()
+    {
+        $subject = $this->faker->unique()->sentence;
+
+        $mail = new AssertableMessage(
+            (new Email())->subject($this->faker->unique()->sentence)
+        );
 
         $this->assertMailNotSubject($subject, $mail);
     }

--- a/tests/ToAssertionsTest.php
+++ b/tests/ToAssertionsTest.php
@@ -4,14 +4,32 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class ToAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailSentTo
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailSentToSingleEmail()
     {
         $email = $this->faker->email;
 
         $mail = (new Email())->to($email);
+
+        $this->assertMailSentTo($email, $mail);
+    }
+
+    public function testMailSentToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($email)
+        );
 
         $this->assertMailSentTo($email, $mail);
     }
@@ -40,11 +58,28 @@ class ToAssertionsTest extends TestCase
         $this->assertMailSentTo($emails, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailNotSentTo
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailNotSentToSingleEmail()
     {
         $email = $this->faker->unique()->email;
 
         $mail = (new Email())->to($this->faker->unique()->email);
+
+        $this->assertMailNotSentTo($email, $mail);
+    }
+
+    public function testMailNotSentToSingleEmailViaAssertableMessage()
+    {
+        $email = $this->faker->unique()->email;
+
+        $mail = new AssertableMessage(
+            (new Email())->to($this->faker->unique()->email)
+        );
 
         $this->assertMailNotSentTo($email, $mail);
     }

--- a/tests/UnstructuredHeaderAssertionsTest.php
+++ b/tests/UnstructuredHeaderAssertionsTest.php
@@ -4,15 +4,33 @@ namespace Tests;
 
 use Symfony\Component\Mime\Email;
 use PHPUnit\Framework\ExpectationFailedException;
+use KirschbaumDevelopment\MailIntercept\AssertableMessage;
 
 class UnstructuredHeaderAssertionsTest extends TestCase
 {
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailHasHeader
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailHasHeader()
     {
         $header = $this->faker->slug;
 
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->word);
+
+        $this->assertMailHasHeader($header, $mail);
+    }
+
+    public function testMailHasHeaderViaAssertableMessage()
+    {
+        $header = $this->faker->slug;
+
+        $mail = new Email();
+        $mail->getHeaders()->addTextHeader($header, $this->faker->word);
+        $mail = new AssertableMessage($mail);
 
         $this->assertMailHasHeader($header, $mail);
     }
@@ -30,12 +48,29 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $this->assertMailHasHeader($header, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailMissingHeader
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailMissingHeader()
     {
         $header = $this->faker->unique()->slug;
 
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
+
+        $this->assertMailMissingHeader($header, $mail);
+    }
+
+    public function testMailMissingHeaderViaAssertableMessage()
+    {
+        $header = $this->faker->unique()->slug;
+
+        $mail = new Email();
+        $mail->getHeaders()->addTextHeader($this->faker->unique()->slug, $this->faker->word);
+        $mail = new AssertableMessage($mail);
 
         $this->assertMailMissingHeader($header, $mail);
     }
@@ -53,6 +88,12 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $this->assertMailMissingHeader($header, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailHeaderIs
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailHeaderIs()
     {
         $header = $this->faker->slug;
@@ -60,6 +101,18 @@ class UnstructuredHeaderAssertionsTest extends TestCase
 
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $value);
+
+        $this->assertMailHeaderIs($header, $value, $mail);
+    }
+
+    public function testMailHeaderIsViaAssertableMessage()
+    {
+        $header = $this->faker->slug;
+        $value = $this->faker->word;
+
+        $mail = new Email();
+        $mail->getHeaders()->addTextHeader($header, $value);
+        $mail = new AssertableMessage($mail);
 
         $this->assertMailHeaderIs($header, $value, $mail);
     }
@@ -78,6 +131,12 @@ class UnstructuredHeaderAssertionsTest extends TestCase
         $this->assertMailHeaderIs($header, $value, $mail);
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | assertMailHeaderIsNot
+    |--------------------------------------------------------------------------
+    */
+
     public function testMailHeaderIsNot()
     {
         $header = $this->faker->slug;
@@ -85,6 +144,18 @@ class UnstructuredHeaderAssertionsTest extends TestCase
 
         $mail = new Email();
         $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
+
+        $this->assertMailHeaderIsNot($header, $value, $mail);
+    }
+
+    public function testMailHeaderIsNotViaAssertableMessage()
+    {
+        $header = $this->faker->slug;
+        $value = $this->faker->unique()->word;
+
+        $mail = new Email();
+        $mail->getHeaders()->addTextHeader($header, $this->faker->unique()->word);
+        $mail = new AssertableMessage($mail);
 
         $this->assertMailHeaderIsNot($header, $value, $mail);
     }


### PR DESCRIPTION
This adds some better coverage in the assertions for type-hinting both `Email` and `AssertableMessage` classes. Thanks to @amsoell for pointing this out and creating and initial PR (#10)  for this fix. 