### PR TITLE
Use HTML body when email is HTML for body assertions

### DIFF
--- a/src/Assertions/ContentAssertions.php
+++ b/src/Assertions/ContentAssertions.php
@@ -21,7 +21,7 @@ trait ContentAssertions
 
         $this->{$method}(
             $needle,
-            $mail->getBody()->bodyToString(),
+            $mail->getHtmlBody() ?: $mail->getBody()->bodyToString(),
             "The expected [{$needle}] string was not found in the body."
         );
     }
@@ -40,7 +40,7 @@ trait ContentAssertions
 
         $this->{$method}(
             $needle,
-            $mail->getBody()->bodyToString(),
+            $mail->getHtmlBody() ?: $mail->getBody()->bodyToString(),
             "The expected [{$needle}] string was found in the body."
         );
     }


### PR DESCRIPTION
`$mail->getBody()->bodyToString()` includes line break and carriage return characters injected at unpredictable areas within the email message, making the `assertMailBodyContainsString` assertion unreliable and in the case of finding strings over a certain length, return false every time. 

![Screen Shot 2022-06-14 at 7 17 22 AM](https://user-images.githubusercontent.com/35386780/173570377-d67bec28-e2f2-4125-8ab6-972bf02e1910.png)

This PR uses the `$mail->getHtmlBody()` method if it is an HTML email and falls back to `$mail->getBody()->bodyToString()` in case it is a plain text email. This method does not output line breaks, making assertions against body text far more reliable.

![Screen Shot 2022-06-14 at 7 16 47 AM](https://user-images.githubusercontent.com/35386780/173570594-514286d1-2dbd-4224-ab95-2fff2d9b244b.png)
 